### PR TITLE
feat: show paralegals their assigned cases on My Cases page

### DIFF
--- a/db/cases.py
+++ b/db/cases.py
@@ -53,8 +53,8 @@ def get_next_case_color() -> str:
 
 def get_all_cases(status_filter: Optional[str] = None, limit: int = None,
                   offset: int = None, attorney_ids: List[int] = None,
-                  unassigned: bool = False) -> dict:
-    """Get all cases with optional status filter and attorney filter."""
+                  unassigned: bool = False, paralegal_ids: List[int] = None) -> dict:
+    """Get all cases with optional status filter and attorney/paralegal filter."""
     with SessionLocal() as session:
         filters = []
         if status_filter:
@@ -67,6 +67,8 @@ def get_all_cases(status_filter: Optional[str] = None, limit: int = None,
                 filters.append(Case.status.in_(statuses))
         if attorney_ids:
             filters.append(Case.attorney_ids.op('&&')(cast(attorney_ids, SA_ARRAY(Integer()))))
+        elif paralegal_ids:
+            filters.append(Case.paralegal_ids.op('&&')(cast(paralegal_ids, SA_ARRAY(Integer()))))
         elif unassigned:
             filters.append(or_(
                 Case.attorney_ids == None,

--- a/frontend/src/pages/cases/index.tsx
+++ b/frontend/src/pages/cases/index.tsx
@@ -37,11 +37,18 @@ export default function MyCasesPage() {
     return () => mq.removeEventListener("change", handler)
   }, [])
 
-  const attorneyIds = user ? [user.id] : undefined
+  const isParalegal = user?.position === "paralegal"
+  const attorneyIds = user && !isParalegal ? [user.id] : undefined
+  const paralegalIds = user && isParalegal ? [user.id] : undefined
 
   const { data: casesData, isLoading } = useQuery({
-    queryKey: ["cases", "mine", user?.id],
-    queryFn: () => getCases({ attorney_ids: attorneyIds, limit: 2000 }),
+    queryKey: ["cases", "mine", user?.id, isParalegal],
+    queryFn: () =>
+      getCases({
+        attorney_ids: attorneyIds,
+        paralegal_ids: paralegalIds,
+        limit: 2000,
+      }),
     enabled: !!user,
   })
 

--- a/frontend/src/services/cases.ts
+++ b/frontend/src/services/cases.ts
@@ -13,6 +13,7 @@ interface GetCasesParams {
   limit?: number
   offset?: number
   attorney_ids?: number[]
+  paralegal_ids?: number[]
   unassigned?: boolean
 }
 
@@ -25,6 +26,8 @@ export async function getCases(
   if (params.offset != null) searchParams.set("offset", String(params.offset))
   if (params.attorney_ids?.length)
     searchParams.set("attorney_ids", params.attorney_ids.join(","))
+  if (params.paralegal_ids?.length)
+    searchParams.set("paralegal_ids", params.paralegal_ids.join(","))
   if (params.unassigned) searchParams.set("unassigned", "true")
 
   const res = await apiFetch(`/api/v1/cases?${searchParams}`)

--- a/routes/cases.py
+++ b/routes/cases.py
@@ -27,14 +27,17 @@ def register_case_routes(mcp):
         limit = int(limit) if limit else DEFAULT_PAGE_SIZE
         offset = int(offset)
 
-        # Attorney filter params
+        # Attorney/paralegal filter params
         attorney_ids_param = request.query_params.get("attorney_ids")
         attorney_ids = [int(x) for x in attorney_ids_param.split(",")] if attorney_ids_param else None
+        paralegal_ids_param = request.query_params.get("paralegal_ids")
+        paralegal_ids = [int(x) for x in paralegal_ids_param.split(",")] if paralegal_ids_param else None
         unassigned = request.query_params.get("unassigned", "false").lower() == "true"
 
         result = await asyncio.to_thread(
             db.get_all_cases, status, limit=limit, offset=offset,
-            attorney_ids=attorney_ids, unassigned=unassigned
+            attorney_ids=attorney_ids, paralegal_ids=paralegal_ids,
+            unassigned=unassigned,
         )
         return JSONResponse({
             "cases": result["cases"],


### PR DESCRIPTION
The My Cases page filtered cases by attorney_ids using the logged-in
user's id, so paralegals saw an empty list. Switch to paralegal_ids
when the user's position is "paralegal", and add the corresponding
paralegal_ids filter to the backend list-cases endpoint.

https://claude.ai/code/session_01Lzk5LyKmg3HCQcT4rsHfcb