### PR TITLE
Show date_of_injury column only in filing-deadlines tab

### DIFF
--- a/frontend/src/pages/cases/all.tsx
+++ b/frontend/src/pages/cases/all.tsx
@@ -67,7 +67,7 @@ function getColumnVisibility(tab: TabDef, mobile: boolean): VisibilityState {
   return {
     details: !mobile,
     attorneys: !mobile,
-    date_of_injury: !mobile,
+    date_of_injury: !mobile && tab.id === "filing-deadlines",
     trial_date: !mobile && tab.visibleDateCols.includes("trial_date"),
     claim_deadline: !mobile && tab.visibleDateCols.includes("claim_deadline"),
     complaint_deadline: !mobile && tab.visibleDateCols.includes("complaint_deadline"),


### PR DESCRIPTION
## Summary
Restrict the visibility of the `date_of_injury` column to only appear in the "filing-deadlines" tab, while keeping it hidden on mobile and in other tabs.

## Changes
- Modified `getColumnVisibility()` in `frontend/src/pages/cases/all.tsx` to conditionally show `date_of_injury` only when viewing the "filing-deadlines" tab on desktop
- The column now respects both the mobile breakpoint AND the active tab context, reducing visual clutter in other case views

## Implementation Details
The `date_of_injury` column visibility now depends on two conditions:
1. Not on mobile (`!mobile`)
2. Currently viewing the "filing-deadlines" tab (`tab.id === "filing-deadlines"`)

This follows the same pattern already used for other date columns like `trial_date` and `claim_deadline`, which conditionally appear based on `tab.visibleDateCols`.

https://claude.ai/code/session_01F8vMMoGhFeMhd6dXaX69QT