### PR TITLE
feat: add proposed_trial_dates for multiple tentative trial dates

### DIFF
--- a/alembic/versions/737cceef5114_add_proposed_trial_dates_to_cases.py
+++ b/alembic/versions/737cceef5114_add_proposed_trial_dates_to_cases.py
@@ -1,0 +1,27 @@
+"""add proposed_trial_dates to cases
+
+Revision ID: 737cceef5114
+Revises: 82eb72f36278
+Create Date: 2026-05-14 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '737cceef5114'
+down_revision: Union[str, Sequence[str], None] = '82eb72f36278'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('cases', sa.Column('proposed_trial_dates', sa.ARRAY(sa.Date()), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('cases', 'proposed_trial_dates')

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -58,6 +58,7 @@ from .cases import (
     create_case,
     update_case,
     delete_case,
+    confirm_trial_date,
     search_cases,
     get_dashboard_stats,
     # Staff assignments

--- a/db/cases.py
+++ b/db/cases.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, func, literal_column, or_, cast, Integer, ARRAY a
 from sqlalchemy.orm import aliased
 
 from .session import SessionLocal
-from .validation import validate_case_status, validate_date_format
+from .validation import validate_case_status, validate_date_format, ValidationError
 from models import (
     Case, User, PersonRole, Role, Person, Event, Task,
     Proceeding, ProceedingJudge, Judge, Jurisdiction,
@@ -30,6 +30,8 @@ def _sv(val):
     """Serialize a single value to JSON-safe format."""
     if val is None:
         return None
+    if isinstance(val, list):
+        return [_sv(v) for v in val]
     if isinstance(val, (datetime.datetime, datetime.date, datetime.time)):
         return val.isoformat()
     if isinstance(val, UUID):
@@ -128,6 +130,7 @@ def get_all_cases(status_filter: Optional[str] = None, limit: int = None,
                 Case.id, Case.case_name, Case.short_name, Case.status,
                 Case.print_code, Case.attorney_ids, Case.paralegal_ids,
                 Case.date_of_injury, Case.trial_date,
+                Case.proposed_trial_dates,
                 Case.trial_likelihood, Case.trial_likelihood_note,
                 Case.trial_estimated_days,
                 Case.claim_deadline, Case.complaint_deadline, Case.color,
@@ -177,6 +180,7 @@ def get_case_by_id(case_id: int) -> Optional[dict]:
             "result": case.result,
             "date_of_injury": _sv(case.date_of_injury),
             "trial_date": _sv(case.trial_date),
+            "proposed_trial_dates": _sv(case.proposed_trial_dates),
             "trial_likelihood": case.trial_likelihood,
             "trial_likelihood_note": case.trial_likelihood_note,
             "trial_estimated_days": case.trial_estimated_days,
@@ -391,7 +395,8 @@ def update_case(case_id: int, **kwargs) -> Optional[dict]:
     allowed_fields = [
         "case_name", "short_name", "status", "print_code",
         "case_summary", "result", "date_of_injury", "notes",
-        "trial_date", "trial_likelihood", "trial_likelihood_note",
+        "trial_date", "proposed_trial_dates",
+        "trial_likelihood", "trial_likelihood_note",
         "trial_estimated_days", "claim_deadline", "complaint_deadline",
     ]
 
@@ -409,6 +414,10 @@ def update_case(case_id: int, **kwargs) -> Optional[dict]:
 
             if field == "status":
                 validate_case_status(value)
+            elif field == "proposed_trial_dates":
+                if isinstance(value, list):
+                    for d in value:
+                        validate_date_format(d, "proposed_trial_dates")
             elif field in ("date_of_injury", "trial_date", "claim_deadline", "complaint_deadline"):
                 validate_date_format(value, field)
 
@@ -431,6 +440,27 @@ def delete_case(case_id: int) -> bool:
         session.delete(case)
         session.commit()
         return True
+
+
+def confirm_trial_date(case_id: int, confirmed_date: str) -> Optional[dict]:
+    """Move a proposed date to trial_date and clear proposed list."""
+    validate_date_format(confirmed_date, "confirmed_date")
+    with SessionLocal() as session:
+        case = session.get(Case, case_id)
+        if not case:
+            return None
+        proposed = case.proposed_trial_dates or []
+        parsed = datetime.date.fromisoformat(confirmed_date)
+        if parsed not in proposed:
+            raise ValidationError(
+                f"Date {confirmed_date} is not in proposed dates: "
+                f"{[d.isoformat() for d in proposed]}"
+            )
+        case.trial_date = parsed
+        case.proposed_trial_dates = None
+        case.updated_at = func.now()
+        session.commit()
+    return get_case_by_id(case_id)
 
 
 def search_cases(query: str = None, case_number: str = None, person_name: str = None,

--- a/db/trial_calendar.py
+++ b/db/trial_calendar.py
@@ -83,7 +83,51 @@ def get_trial_calendar(months_ahead: int = 6, months_behind: int = 1) -> dict:
                 "jurisdiction_name": r.jurisdiction_name,
                 "case_number": r.case_number,
                 "judge_names": r.judge_names,
+                "proposed": False,
             })
+
+        proposed_stmt = (
+            select(
+                Case.id.label("case_id"),
+                Case.case_name,
+                Case.short_name,
+                Case.color,
+                Case.status,
+                Case.trial_estimated_days,
+                Case.trial_likelihood,
+                Case.attorney_ids,
+                Case.proposed_trial_dates,
+                jurisdiction_sq,
+                case_number_sq,
+                judge_names_sq,
+            )
+            .where(
+                Case.proposed_trial_dates.isnot(None),
+                Case.status != "Closed",
+            )
+        )
+        proposed_rows = session.execute(proposed_stmt).fetchall()
+
+        for r in proposed_rows:
+            for d in (r.proposed_trial_dates or []):
+                if range_start <= d <= range_end:
+                    trials.append({
+                        "case_id": r.case_id,
+                        "case_name": r.case_name,
+                        "short_name": r.short_name,
+                        "color": r.color,
+                        "status": r.status,
+                        "trial_date": d.isoformat(),
+                        "trial_estimated_days": r.trial_estimated_days,
+                        "trial_likelihood": r.trial_likelihood,
+                        "attorney_ids": r.attorney_ids or [],
+                        "jurisdiction_name": r.jurisdiction_name,
+                        "case_number": r.case_number,
+                        "judge_names": r.judge_names,
+                        "proposed": True,
+                    })
+
+        trials.sort(key=lambda t: t["trial_date"] or "")
 
         event_stmt = (
             select(Event)

--- a/frontend/src/services/cases.ts
+++ b/frontend/src/services/cases.ts
@@ -77,6 +77,7 @@ export async function createCase(
 
 export type UpdateCaseData = Partial<CreateCaseData> & {
   notes?: string
+  proposed_trial_dates?: string[] | null
   trial_likelihood?: number | null
   trial_likelihood_note?: string | null
   trial_estimated_days?: number | null

--- a/frontend/src/services/trial-calendar.ts
+++ b/frontend/src/services/trial-calendar.ts
@@ -13,6 +13,7 @@ export interface TrialItem {
   jurisdiction_name: string | null
   case_number: string | null
   judge_names: string | null
+  proposed: boolean
 }
 
 export interface BlockingEvent {

--- a/frontend/src/types/case.ts
+++ b/frontend/src/types/case.ts
@@ -23,6 +23,7 @@ export interface CaseListItem {
   paralegal_ids: number[] | null
   date_of_injury: string | null
   trial_date: string | null
+  proposed_trial_dates: string[] | null
   trial_likelihood: number | null
   trial_likelihood_note: string | null
   trial_estimated_days: number | null
@@ -48,6 +49,7 @@ export interface CaseDetail {
   result: string | null
   date_of_injury: string | null
   trial_date: string | null
+  proposed_trial_dates: string[] | null
   trial_likelihood: number | null
   trial_likelihood_note: string | null
   trial_estimated_days: number | null

--- a/models.py
+++ b/models.py
@@ -275,6 +275,9 @@ class Case(Base):
     result: Mapped[Optional[str]] = mapped_column(Text)
     date_of_injury: Mapped[Optional[datetime.date]] = mapped_column(Date)
     trial_date: Mapped[Optional[datetime.date]] = mapped_column(Date)
+    proposed_trial_dates: Mapped[Optional[list[datetime.date]]] = mapped_column(
+        ARRAY(Date), nullable=True
+    )
     trial_likelihood: Mapped[Optional[int]] = mapped_column(Integer)
     trial_likelihood_note: Mapped[Optional[str]] = mapped_column(Text)
     trial_estimated_days: Mapped[Optional[int]] = mapped_column(Integer)

--- a/routes/cases.py
+++ b/routes/cases.py
@@ -136,6 +136,24 @@ def register_case_routes(mcp):
             return JSONResponse({"success": True})
         return api_error("Case not found", "NOT_FOUND", 404)
 
+    @mcp.custom_route("/api/v1/cases/{case_id}/confirm-trial-date", methods=["POST"])
+    async def api_confirm_trial_date(request):
+        """Confirm a proposed trial date — sets trial_date and clears proposed list."""
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        body = await request.json()
+        confirmed_date = body.get("confirmed_date")
+        if not confirmed_date:
+            return api_error("confirmed_date is required", "VALIDATION_ERROR", 400)
+        try:
+            result = await asyncio.to_thread(db.confirm_trial_date, case_id, confirmed_date)
+        except Exception as e:
+            return api_error(str(e), "VALIDATION_ERROR", 400)
+        if not result:
+            return api_error("Case not found", "NOT_FOUND", 404)
+        return JSONResponse({"success": True, "case": result})
+
     # =========================================================================
     # Case Staff Assignments (Attorneys & Paralegals)
     # =========================================================================

--- a/schemas/inputs.py
+++ b/schemas/inputs.py
@@ -36,6 +36,7 @@ class UpdateCaseInput(BaseModel):
     result: Optional[str] = None
     date_of_injury: Optional[str] = None
     trial_date: Optional[str] = None
+    proposed_trial_dates: Optional[list[str]] = None
     trial_likelihood: Optional[int] = None
     trial_likelihood_note: Optional[str] = None
     trial_estimated_days: Optional[int] = None

--- a/schemas/outputs.py
+++ b/schemas/outputs.py
@@ -452,6 +452,7 @@ class CaseListOut(BaseModel):
     defendant_count: Optional[int] = None
     pending_task_count: Optional[int] = None
     upcoming_event_count: Optional[int] = None
+    proposed_trial_dates: Optional[list[str]] = None
     trial_likelihood: Optional[int] = None
     trial_likelihood_note: Optional[str] = None
     trial_estimated_days: Optional[int] = None
@@ -467,6 +468,7 @@ class CaseDetailOut(BaseModel):
     case_summary: Optional[str] = None
     result: Optional[str] = None
     date_of_injury: Optional[str] = None
+    proposed_trial_dates: Optional[list[str]] = None
     trial_likelihood: Optional[int] = None
     trial_likelihood_note: Optional[str] = None
     trial_estimated_days: Optional[int] = None

--- a/tools.py
+++ b/tools.py
@@ -128,8 +128,8 @@ class SearchInput(BaseModel):
 
 class ManageCaseInput(BaseModel):
     """Create, update, or delete a case."""
-    action: Literal["create", "update", "delete"] = Field(..., description="Action to perform")
-    case_id: Optional[int] = Field(None, description="Required for update/delete")
+    action: Literal["create", "update", "delete", "confirm_trial_date"] = Field(..., description="Action to perform")
+    case_id: Optional[int] = Field(None, description="Required for update/delete/confirm_trial_date")
     case_name: Optional[str] = Field(None, description="Case name (required for create)")
     short_name: Optional[str] = Field(None, description="Short display name")
     status: Optional[CaseStatus] = Field(None, description="Case status")
@@ -137,7 +137,8 @@ class ManageCaseInput(BaseModel):
     case_summary: Optional[str] = Field(None, description="Case summary text")
     result: Optional[str] = Field(None, description="Case result/outcome")
     date_of_injury: Optional[str] = Field(None, description="Date of injury (YYYY-MM-DD)")
-    trial_date: Optional[str] = Field(None, description="Trial date (YYYY-MM-DD)")
+    trial_date: Optional[str] = Field(None, description="Trial date (YYYY-MM-DD). For confirm_trial_date: the proposed date to confirm.")
+    proposed_trial_dates: Optional[list[str]] = Field(None, description="Proposed trial dates submitted to court (list of YYYY-MM-DD)")
     trial_likelihood: Optional[int] = Field(None, description="Trial likelihood percentage (0-100)")
     trial_estimated_days: Optional[int] = Field(None, description="Estimated trial duration in days")
     claim_deadline: Optional[str] = Field(None, description="Government claim filing deadline (YYYY-MM-DD)")
@@ -700,7 +701,7 @@ def register_tools(mcp):
                 if not data.case_id:
                     return validation_error("case_id is required for update")
                 kwargs = {}
-                for field in ["case_name", "short_name", "status", "print_code", "case_summary", "result", "date_of_injury", "trial_date", "claim_deadline", "complaint_deadline"]:
+                for field in ["case_name", "short_name", "status", "print_code", "case_summary", "result", "date_of_injury", "trial_date", "proposed_trial_dates", "claim_deadline", "complaint_deadline"]:
                     val = getattr(data, field)
                     if val is not None:
                         kwargs[field] = val
@@ -708,6 +709,16 @@ def register_tools(mcp):
                 if not result:
                     return not_found_error("Case")
                 return {"success": True, "message": f"Case #{data.case_id} updated", "case_id": data.case_id}
+
+            elif data.action == "confirm_trial_date":
+                if not data.case_id:
+                    return validation_error("case_id is required for confirm_trial_date")
+                if not data.trial_date:
+                    return validation_error("trial_date is required (the proposed date to confirm)")
+                result = db.confirm_trial_date(data.case_id, data.trial_date)
+                if not result:
+                    return not_found_error("Case")
+                return {"success": True, "message": f"Trial date {data.trial_date} confirmed for case #{data.case_id}", "case_id": data.case_id}
 
             elif data.action == "delete":
                 if not data.case_id:


### PR DESCRIPTION
## Summary

- Adds `proposed_trial_dates DATE[]` array column on the `cases` table to track multiple dates submitted to court, alongside the existing confirmed `trial_date`
- Adds `confirm_trial_date` workflow (REST endpoint + MCP tool action) that promotes a proposed date to `trial_date` and clears the rest
- Proposed dates appear as tentative items (`"proposed": true`) in the trial calendar API
- Fixes `_sv()` serializer to handle `ARRAY(Date)` columns (lists of dates weren't being serialized to ISO strings)

## Files changed

| Area | Files |
|------|-------|
| Model + migration | `models.py`, `alembic/versions/737cceef5114_*.py` |
| DB layer | `db/cases.py`, `db/__init__.py`, `db/trial_calendar.py` |
| Schemas | `schemas/inputs.py`, `schemas/outputs.py` |
| API | `routes/cases.py` (new `POST /cases/{id}/confirm-trial-date`) |
| MCP | `tools.py` (new `confirm_trial_date` action on `manage_case`) |
| Frontend types | `types/case.ts`, `services/cases.ts`, `services/trial-calendar.ts` |

## Test plan

- [ ] Run migration: `alembic upgrade head`, verify column exists
- [ ] `PUT /api/v1/cases/{id}` with `proposed_trial_dates: ["2026-07-15", "2026-08-01"]` — verify response
- [ ] `GET /api/v1/trial-calendar` — proposed dates appear with `proposed: true`
- [ ] `POST /api/v1/cases/{id}/confirm-trial-date` with `{"confirmed_date": "2026-07-15"}` — trial_date set, proposed cleared
- [ ] MCP: `manage_case` update with `proposed_trial_dates`, and `confirm_trial_date` action
- [ ] `npm run type-check` passes in frontend

https://claude.ai/code/session_01WhXjyqV3o7ediJEHfCvTz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhXjyqV3o7ediJEHfCvTz7)_