### PR TITLE
feat: show year under month label in trial calendar gutter

### DIFF
--- a/frontend/src/pages/trial-calendar/components/calendar-helpers.ts
+++ b/frontend/src/pages/trial-calendar/components/calendar-helpers.ts
@@ -299,9 +299,7 @@ export function buildWeekRows(
       laneCount,
       conflictColumns,
       monthLabel: isFirst ? format(mid, "MMMM") : null,
-      weekLabel: isFirst
-        ? `wk of ${format(monday, "MMM d")}`
-        : format(monday, "MMM d"),
+      weekLabel: isFirst ? format(mid, "yyyy") : format(monday, "MMM d"),
     }
   })
 }


### PR DESCRIPTION
Replace "wk of ..." with the year on first-of-month rows so each month
header is paired with its year.

https://claude.ai/code/session_01KcZitBX8eSP5TzYv8WQxH5