### PR TITLE
feat: secondary sort tasks/events, group My Cases by status, filter All Cases

### DIFF
--- a/frontend/src/pages/cases/all.tsx
+++ b/frontend/src/pages/cases/all.tsx
@@ -191,6 +191,7 @@ export default function AllCasesPage() {
         onSortingChange={setSorting}
         columnVisibility={columnVisibility}
         onColumnVisibilityChange={setColumnVisibility}
+        showFilters
       />
     </div>
   )

--- a/frontend/src/pages/cases/columns.tsx
+++ b/frontend/src/pages/cases/columns.tsx
@@ -90,6 +90,7 @@ export function getColumns(options: {
     },
     {
       id: "attorneys",
+      accessorFn: (row) => row.attorney_ids ?? [],
       header: "Team",
       cell: ({ row }) => {
         const ids = row.original.attorney_ids ?? []
@@ -111,6 +112,11 @@ export function getColumns(options: {
             ))}
           </div>
         )
+      },
+      filterFn: (row, id, value: string[]) => {
+        const ids = (row.getValue(id) as number[]) ?? []
+        if (!value?.length) return true
+        return ids.some((aid) => value.includes(String(aid)))
       },
     },
     {
@@ -158,6 +164,10 @@ export function getColumns(options: {
         <DataTableColumnHeader column={column} title="Status" />
       ),
       cell: ({ row }) => <CaseStatusBadge status={row.original.status} />,
+      filterFn: (row, id, value: string[]) => {
+        if (!value?.length) return true
+        return value.includes(row.getValue(id) as string)
+      },
     },
     {
       id: "preview",

--- a/frontend/src/pages/cases/components/case-table.tsx
+++ b/frontend/src/pages/cases/components/case-table.tsx
@@ -4,6 +4,8 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   getFilteredRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
   type SortingState,
   type ColumnFiltersState,
   type VisibilityState,
@@ -18,6 +20,8 @@ import {
   NoteEditIcon,
   MoreHorizontalIcon,
   Download04Icon,
+  TableIcon,
+  LayersLogoIcon,
 } from "@hugeicons/core-free-icons"
 import { useNavigate } from "react-router"
 import { getCase, createCase, type CreateCaseData, exportCaseReport } from "@/services/cases"
@@ -26,6 +30,8 @@ import { getColumns } from "@/pages/cases/columns"
 import { CaseQuickView } from "@/pages/cases/components/case-quick-view"
 import { CaseFormDialog } from "@/pages/cases/components/case-form-dialog"
 import { CaseChatDialog } from "@/pages/cases/components/case-chat-dialog"
+import { CaseGroupedView } from "@/pages/cases/components/case-grouped-view"
+import { DataTableFacetedFilter } from "@/components/common/data-table-faceted-filter"
 import {
   Table,
   TableBody,
@@ -43,7 +49,26 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { CaseListItem } from "@/types/case"
+import { cn } from "@/lib/utils"
+import type { CaseListItem, CaseStatus } from "@/types/case"
+
+const ALL_STATUSES: CaseStatus[] = [
+  "Signing Up",
+  "Prospective",
+  "Pre-Filing",
+  "Pleadings",
+  "Discovery",
+  "Expert Discovery",
+  "Pre-trial",
+  "Trial",
+  "Post-Trial",
+  "Appeal",
+  "Settl. Pend.",
+  "Stayed",
+  "Closed",
+]
+
+export type CaseGroupBy = "none" | "status"
 
 export type UsersMap = Map<number, { id: number; first_name: string; last_name: string; initials: string }>
 
@@ -56,6 +81,9 @@ interface CaseTableProps {
   onSortingChange: (s: SortingState) => void
   columnVisibility: VisibilityState
   onColumnVisibilityChange: (v: VisibilityState) => void
+  showFilters?: boolean
+  groupBy?: CaseGroupBy
+  onGroupByChange?: (g: CaseGroupBy) => void
 }
 
 export function CaseTable({
@@ -67,6 +95,9 @@ export function CaseTable({
   onSortingChange,
   columnVisibility,
   onColumnVisibilityChange,
+  showFilters,
+  groupBy = "none",
+  onGroupByChange,
 }: CaseTableProps) {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -109,10 +140,36 @@ export function CaseTable({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
     meta: { onPreview },
   })
 
   const nameColumn = table.getColumn("case_name")
+  const statusColumn = table.getColumn("status")
+  const attorneysColumn = table.getColumn("attorneys")
+
+  const statusOptions = useMemo(
+    () => ALL_STATUSES.map((s) => ({ label: s, value: s })),
+    []
+  )
+
+  const attorneyOptions = useMemo(() => {
+    const users = Array.from(usersMap.values())
+    users.sort((a, b) =>
+      `${a.first_name} ${a.last_name}`.localeCompare(`${b.first_name} ${b.last_name}`)
+    )
+    return users.map((u) => ({
+      label: `${u.first_name} ${u.last_name}`.trim() || u.initials,
+      value: String(u.id),
+    }))
+  }, [usersMap])
+
+  const filteredCases = useMemo(
+    () => table.getFilteredRowModel().rows.map((r) => r.original),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [table.getFilteredRowModel().rows]
+  )
 
   const { data: selectedCase } = useQuery({
     queryKey: ["case", selectedCaseId],
@@ -122,8 +179,8 @@ export function CaseTable({
 
   return (
     <>
-      {/* Search + actions */}
-      <div className="flex items-center gap-2">
+      {/* Search + filters + actions */}
+      <div className="flex flex-wrap items-center gap-2">
         <div className="relative min-w-0 flex-1 max-w-sm">
           <HugeiconsIcon
             icon={Search01Icon}
@@ -136,6 +193,62 @@ export function CaseTable({
             className="h-8 pl-8"
           />
         </div>
+        {showFilters && statusColumn && (
+          <DataTableFacetedFilter
+            column={statusColumn}
+            title="Status"
+            options={statusOptions}
+          />
+        )}
+        {showFilters && attorneysColumn && (
+          <DataTableFacetedFilter
+            column={attorneysColumn}
+            title="Attorney"
+            options={attorneyOptions}
+          />
+        )}
+        {showFilters && columnFilters.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setColumnFilters([])}
+            className="h-8 px-2 text-xs"
+          >
+            Clear
+          </Button>
+        )}
+        {onGroupByChange && (
+          <div className="flex items-center border h-8">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onGroupByChange("none")}
+              className={cn(
+                "h-full px-2.5 border-0",
+                groupBy === "none"
+                  ? "bg-foreground text-background hover:bg-foreground hover:text-background"
+                  : "text-muted-foreground"
+              )}
+              title="Table view"
+            >
+              <HugeiconsIcon icon={TableIcon} className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onGroupByChange("status")}
+              className={cn(
+                "h-full px-2.5 border-0",
+                groupBy === "status"
+                  ? "bg-foreground text-background hover:bg-foreground hover:text-background"
+                  : "text-muted-foreground"
+              )}
+              title="Group by status"
+            >
+              <HugeiconsIcon icon={LayersLogoIcon} className="size-3.5" />
+            </Button>
+          </div>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="icon-sm" className="h-8 w-8">
@@ -159,7 +272,14 @@ export function CaseTable({
         </DropdownMenu>
       </div>
 
-      {/* Table */}
+      {/* Table or grouped view */}
+      {groupBy === "status" ? (
+        <CaseGroupedView
+          cases={filteredCases}
+          isLoading={isLoading}
+          usersMap={usersMap}
+        />
+      ) : (
       <div className="border">
         <Table>
           <TableHeader>
@@ -218,6 +338,7 @@ export function CaseTable({
           </TableBody>
         </Table>
       </div>
+      )}
 
       {/* Dialogs */}
       <CaseQuickView

--- a/frontend/src/pages/cases/index.tsx
+++ b/frontend/src/pages/cases/index.tsx
@@ -1,13 +1,31 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect, useMemo, useCallback } from "react"
 import type { SortingState, VisibilityState } from "@tanstack/react-table"
+import { useSearchParams } from "react-router"
 import { useQuery } from "@tanstack/react-query"
 import { useAuth } from "@/hooks/use-auth"
 import { getCases } from "@/services/cases"
 import { getUsers } from "@/services/users"
-import { CaseTable } from "@/pages/cases/components/case-table"
+import { CaseTable, type CaseGroupBy } from "@/pages/cases/components/case-table"
 
 export default function MyCasesPage() {
   const { user } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const groupBy = (searchParams.get("group") as CaseGroupBy) || "none"
+  const setGroupBy = useCallback(
+    (g: CaseGroupBy) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (g === "none") {
+          next.delete("group")
+        } else {
+          next.set("group", g)
+        }
+        return next
+      }, { replace: true })
+    },
+    [setSearchParams]
+  )
 
   const [sorting, setSorting] = useState<SortingState>([])
   const [isMobile, setIsMobile] = useState(() => window.matchMedia("(max-width: 639px)").matches)
@@ -93,6 +111,8 @@ export default function MyCasesPage() {
         onSortingChange={setSorting}
         columnVisibility={columnVisibility}
         onColumnVisibilityChange={setColumnVisibility}
+        groupBy={groupBy}
+        onGroupByChange={setGroupBy}
       />
     </div>
   )

--- a/frontend/src/pages/events/group-events.ts
+++ b/frontend/src/pages/events/group-events.ts
@@ -29,11 +29,21 @@ function endOfWeek(date: Date): Date {
   return d
 }
 
-const sortByDateAsc = (a: EventListItem, b: EventListItem) =>
-  a.date.localeCompare(b.date)
+// "HH:MM" or "HH:MM:SS"; null sorts after timed events for asc, before for desc
+const timeRankAsc = (t: string | null) => t ?? "99:99"
+const timeRankDesc = (t: string | null) => t ?? ""
 
-const sortByDateDesc = (a: EventListItem, b: EventListItem) =>
-  b.date.localeCompare(a.date)
+const sortByDateAsc = (a: EventListItem, b: EventListItem) => {
+  const dateCmp = a.date.localeCompare(b.date)
+  if (dateCmp !== 0) return dateCmp
+  return timeRankAsc(a.time).localeCompare(timeRankAsc(b.time))
+}
+
+const sortByDateDesc = (a: EventListItem, b: EventListItem) => {
+  const dateCmp = b.date.localeCompare(a.date)
+  if (dateCmp !== 0) return dateCmp
+  return timeRankDesc(b.time).localeCompare(timeRankDesc(a.time))
+}
 
 export function groupEventsByDate(events: EventListItem[]): EventGroup[] {
   const today = todayMidnight()

--- a/frontend/src/pages/tasks/group-tasks.ts
+++ b/frontend/src/pages/tasks/group-tasks.ts
@@ -69,14 +69,26 @@ export function groupTasksByDate(tasks: TaskListItem[]): TaskGroup[] {
     }
   }
 
-  // Sort tasks within each bucket by due_date
-  const sortByDate = (a: TaskListItem, b: TaskListItem) => {
+  // Sort tasks within each bucket by due_date, then by urgency (Urgent first)
+  const urgencyRank: Record<string, number> = {
+    Urgent: 0,
+    High: 1,
+    Medium: 2,
+    Low: 3,
+  }
+  const rankUrgency = (u: string | null) =>
+    u && urgencyRank[u] !== undefined ? urgencyRank[u] : 99
+
+  const sortByDateThenUrgency = (a: TaskListItem, b: TaskListItem) => {
+    if (!a.due_date && !b.due_date) return rankUrgency(a.urgency) - rankUrgency(b.urgency)
     if (!a.due_date) return 1
     if (!b.due_date) return -1
-    return a.due_date.localeCompare(b.due_date)
+    const dateCmp = a.due_date.localeCompare(b.due_date)
+    if (dateCmp !== 0) return dateCmp
+    return rankUrgency(a.urgency) - rankUrgency(b.urgency)
   }
   for (const key of Object.keys(buckets)) {
-    buckets[key].sort(sortByDate)
+    buckets[key].sort(sortByDateThenUrgency)
   }
 
   const config: { key: string; label: string; sortOrder: number }[] = [


### PR DESCRIPTION
- Tasks sorted by date now break ties on urgency (Urgent → High → Medium → Low)
- Events sorted by date now break ties on time (asc/desc respecting view)
- My Cases page gets a Table/Status group toggle (URL-persisted via ?group=status)
- All Cases page gets Status and Attorney faceted filters via the existing
  DataTableFacetedFilter, with a Clear shortcut when any are active