### PR TITLE
fix: collapse trial calendar actions into overflow menu on mobile

### DIFF
--- a/frontend/src/pages/trial-calendar/components/slot-finder.tsx
+++ b/frontend/src/pages/trial-calendar/components/slot-finder.tsx
@@ -8,7 +8,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -20,8 +19,12 @@ function parseDate(s: string): Date {
   return new Date(y, m - 1, d)
 }
 
-export function SlotFinder() {
-  const [open, setOpen] = useState(false)
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SlotFinder({ open, onOpenChange }: Props) {
   const [estimatedDays, setEstimatedDays] = useState(5)
   const [monthsAhead, setMonthsAhead] = useState(6)
   const [earliestDate, setEarliestDate] = useState("")
@@ -47,13 +50,7 @@ export function SlotFinder() {
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          <HugeiconsIcon icon={SparklesIcon} className="size-3.5" />
-          Find Open Slots
-        </Button>
-      </DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Find Available Trial Slots</DialogTitle>

--- a/frontend/src/pages/trial-calendar/index.tsx
+++ b/frontend/src/pages/trial-calendar/index.tsx
@@ -1,6 +1,13 @@
 import { useState, useMemo, useCallback } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { PrinterIcon, ArrowDown01Icon } from "@hugeicons/core-free-icons"
+import {
+  PrinterIcon,
+  ArrowDown01Icon,
+  MoreHorizontalIcon,
+  SparklesIcon,
+  Sun01Icon,
+  Calendar01Icon,
+} from "@hugeicons/core-free-icons"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { getTrialCalendar, downloadTrialCalendarPdf } from "@/services/trial-calendar"
 import { createEvent, type CreateEventData } from "@/services/events"
@@ -16,6 +23,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
@@ -28,6 +36,7 @@ const MONTHS_BEHIND = 1
 export default function TrialCalendarPage() {
   const [vacationOpen, setVacationOpen] = useState(false)
   const [blockingOpen, setBlockingOpen] = useState(false)
+  const [slotFinderOpen, setSlotFinderOpen] = useState(false)
   const [view, setView] = useState<View>("calendar")
   const [printing, setPrinting] = useState(false)
   const queryClient = useQueryClient()
@@ -69,7 +78,7 @@ export default function TrialCalendarPage() {
   return (
     <div className="flex flex-col gap-6 p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <h1 className="text-2xl font-bold tracking-tight">Trial Calendar</h1>
         <div className="flex items-center gap-2">
           <ToggleGroup
@@ -81,30 +90,75 @@ export default function TrialCalendarPage() {
             <ToggleGroupItem value="calendar" className="px-3 text-xs">Calendar</ToggleGroupItem>
             <ToggleGroupItem value="table" className="px-3 text-xs">Table</ToggleGroupItem>
           </ToggleGroup>
+
+          {/* Desktop: full action buttons */}
+          <div className="hidden md:flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" disabled={printing}>
+                  <HugeiconsIcon icon={PrinterIcon} className="size-3.5" />
+                  {printing ? "Generating..." : "Print"}
+                  <HugeiconsIcon icon={ArrowDown01Icon} className="size-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => handlePrint("list")}>
+                  Print List
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handlePrint("visual")}>
+                  Print Visual
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Button variant="outline" size="sm" onClick={() => setSlotFinderOpen(true)}>
+              <HugeiconsIcon icon={SparklesIcon} className="size-3.5" />
+              Find Open Slots
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setVacationOpen(true)}>
+              Add Vacation
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setBlockingOpen(true)}>
+              Add Event
+            </Button>
+          </div>
+
+          {/* Mobile: overflow menu */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" disabled={printing}>
-                <HugeiconsIcon icon={PrinterIcon} className="size-3.5" />
-                {printing ? "Generating..." : "Print"}
-                <HugeiconsIcon icon={ArrowDown01Icon} className="size-3" />
+              <Button
+                variant="outline"
+                size="icon-sm"
+                className="h-8 w-8 md:hidden"
+                aria-label="More actions"
+                disabled={printing}
+              >
+                <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => handlePrint("list")}>
+            <DropdownMenuContent align="end" className="w-[200px]">
+              <DropdownMenuItem onClick={() => setSlotFinderOpen(true)}>
+                <HugeiconsIcon icon={SparklesIcon} className="mr-2 size-4" />
+                Find Open Slots
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setVacationOpen(true)}>
+                <HugeiconsIcon icon={Sun01Icon} className="mr-2 size-4" />
+                Add Vacation
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setBlockingOpen(true)}>
+                <HugeiconsIcon icon={Calendar01Icon} className="mr-2 size-4" />
+                Add Event
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => handlePrint("list")} disabled={printing}>
+                <HugeiconsIcon icon={PrinterIcon} className="mr-2 size-4" />
                 Print List
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handlePrint("visual")}>
+              <DropdownMenuItem onClick={() => handlePrint("visual")} disabled={printing}>
+                <HugeiconsIcon icon={PrinterIcon} className="mr-2 size-4" />
                 Print Visual
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <SlotFinder />
-          <Button variant="outline" size="sm" onClick={() => setVacationOpen(true)}>
-            Add Vacation
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => setBlockingOpen(true)}>
-            Add Event
-          </Button>
         </div>
       </div>
 
@@ -119,6 +173,7 @@ export default function TrialCalendarPage() {
       ) : null}
 
       {/* Dialogs */}
+      <SlotFinder open={slotFinderOpen} onOpenChange={setSlotFinderOpen} />
       <AddVacationDialog
         open={vacationOpen}
         onOpenChange={setVacationOpen}


### PR DESCRIPTION
The Print, Find Open Slots, Add Vacation, and Add Event buttons overflowed
the header on narrow viewports. On screens below md they're now grouped
under a single MoreHorizontal dropdown; the Calendar/Table toggle stays
visible at all sizes.

SlotFinder is now a controlled dialog (the trigger lives in the parent)
so the same action can be invoked from either the desktop button or the
mobile menu item.