### PR TITLE
Add SMS launch button to intake metadata

### DIFF
--- a/frontend/src/components/common/sms-launch-button.tsx
+++ b/frontend/src/components/common/sms-launch-button.tsx
@@ -1,0 +1,57 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "react-router"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Message01Icon } from "@hugeicons/core-free-icons"
+import { createConversation } from "@/services/sms"
+import { cn } from "@/lib/utils"
+
+interface SmsLaunchButtonProps {
+  phone: string
+  /** Default label applied if a new conversation is created. Ignored if a conversation already exists for this phone. */
+  label?: string
+  caseId?: number
+  personId?: number
+  className?: string
+  title?: string
+}
+
+export function SmsLaunchButton({
+  phone,
+  label,
+  caseId,
+  personId,
+  className,
+  title = "Start or continue SMS conversation",
+}: SmsLaunchButtonProps) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: () => createConversation(phone, label, caseId, personId),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["sms"] })
+      navigate(`/sms/${result.id}`)
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        mutation.mutate()
+      }}
+      disabled={mutation.isPending || !phone}
+      title={title}
+      className={cn(
+        "inline-flex items-center text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+    >
+      <HugeiconsIcon icon={Message01Icon} className="size-3.5" />
+      <span className="sr-only">{title}</span>
+    </button>
+  )
+}

--- a/frontend/src/pages/intakes/components/intake-metadata.tsx
+++ b/frontend/src/pages/intakes/components/intake-metadata.tsx
@@ -6,6 +6,7 @@ import { formatPhone } from "@/lib/utils"
 import { updateIntake } from "@/services/intakes"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { SmsLaunchButton } from "@/components/common/sms-launch-button"
 import {
   Tooltip,
   TooltipContent,
@@ -217,6 +218,10 @@ export function IntakeMetadata({ intake }: IntakeMetadataProps) {
                   <div className="flex items-center gap-2">
                     <HugeiconsIcon icon={CallIcon} className="size-3.5 text-muted-foreground" />
                     <span className="text-xs">{formatPhone(intake.phone)}</span>
+                    <SmsLaunchButton
+                      phone={intake.phone}
+                      label={intake.name ?? undefined}
+                    />
                   </div>
                 )}
                 {intake.contact_relationship && (
@@ -276,6 +281,16 @@ export function IntakeMetadata({ intake }: IntakeMetadataProps) {
                       <div className="flex items-center gap-2">
                         <HugeiconsIcon icon={CallIcon} className="size-3.5 text-muted-foreground" />
                         <span className="text-xs">{formatPhone(intake.referral_phone)}</span>
+                        <SmsLaunchButton
+                          phone={intake.referral_phone}
+                          label={
+                            intake.referral_name
+                              ? `${intake.referral_name} (referral)`
+                              : intake.referral_org
+                                ? `${intake.referral_org} (referral)`
+                                : undefined
+                          }
+                        />
                       </div>
                     )}
                   </>


### PR DESCRIPTION
## Summary
Adds a new `SmsLaunchButton` component that allows users to quickly start or continue SMS conversations directly from the intake metadata view. The button appears next to phone numbers for both the intake contact and referral contact.

## Changes
- **New component**: `SmsLaunchButton` — A reusable button component that:
  - Launches SMS conversations via the `createConversation` API
  - Accepts phone number, optional label, case ID, and person ID
  - Navigates to the conversation view on success
  - Shows error toasts on failure
  - Displays a message icon and is disabled when no phone number is provided

- **Updated `IntakeMetadata`**: Integrated `SmsLaunchButton` in two locations:
  - Next to the intake contact's phone number (uses intake name as label)
  - Next to the referral contact's phone number (uses referral name or organization as label)

## Implementation Details
- Uses React Query's `useMutation` for async conversation creation
- Invalidates the `sms` query cache on success to keep conversations list fresh
- Button is styled consistently with the existing UI (icon-only, muted foreground color)
- Prevents event propagation to avoid unintended parent click handlers
- Includes proper accessibility with `sr-only` title text

https://claude.ai/code/session_0179ivuLyUZpbuhr241RdtqP