### PR TITLE
feat: universal DatePicker with natural language parsing

### DIFF
--- a/frontend/src/components/common/inline-edit-field.tsx
+++ b/frontend/src/components/common/inline-edit-field.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react"
 import { cn } from "@/lib/utils"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { PencilEdit01Icon } from "@hugeicons/core-free-icons"
+import { DatePicker } from "@/components/ui/date-picker"
 
 interface InlineEditFieldProps {
   value: string
@@ -12,7 +13,23 @@ interface InlineEditFieldProps {
   displayClassName?: string
 }
 
-export function InlineEditField({
+export function InlineEditField(props: InlineEditFieldProps) {
+  if (props.type === "date") {
+    return (
+      <DatePicker
+        value={props.value || null}
+        onChange={(date) => props.onSave(date ?? "")}
+        variant="inline"
+        placeholder={props.placeholder ?? "—"}
+        className={props.displayClassName}
+      />
+    )
+  }
+
+  return <InlineEditFieldInner {...props} />
+}
+
+function InlineEditFieldInner({
   value,
   onSave,
   type = "text",
@@ -82,17 +99,7 @@ export function InlineEditField({
         displayClassName
       )}
     >
-      <span className="break-words">
-        {value
-          ? type === "date"
-            ? new Date(value + "T00:00:00").toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })
-            : value
-          : placeholder}
-      </span>
+      <span className="break-words">{value || placeholder}</span>
       <HugeiconsIcon
         icon={PencilEdit01Icon}
         className="size-3 shrink-0 opacity-0 group-hover/edit:opacity-50 transition-opacity"

--- a/frontend/src/pages/cases/components/add-event-dialog.tsx
+++ b/frontend/src/pages/cases/components/add-event-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 
@@ -78,10 +79,9 @@ export function AddEventDialog({
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label className="text-xs">Date</Label>
-              <Input
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
             <div className="space-y-1.5">

--- a/frontend/src/pages/cases/components/add-task-dialog.tsx
+++ b/frontend/src/pages/cases/components/add-task-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -88,10 +89,9 @@ export function AddTaskDialog({ open, onOpenChange, caseId }: AddTaskDialogProps
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label className="text-xs">Due Date</Label>
-              <Input
-                type="date"
-                value={dueDate}
-                onChange={(e) => setDueDate(e.target.value)}
+              <DatePicker
+                value={dueDate || null}
+                onChange={(d) => setDueDate(d ?? "")}
               />
             </div>
             <div className="space-y-1.5">

--- a/frontend/src/pages/cases/components/case-form-dialog.tsx
+++ b/frontend/src/pages/cases/components/case-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -132,12 +133,10 @@ export function CaseFormDialog({
               </Select>
             </div>
             <div className="grid gap-1.5">
-              <Label htmlFor="date_of_injury">Date of Injury</Label>
-              <Input
-                id="date_of_injury"
-                type="date"
-                value={form.date_of_injury}
-                onChange={set("date_of_injury")}
+              <Label>Date of Injury</Label>
+              <DatePicker
+                value={form.date_of_injury || null}
+                onChange={(d) => setForm((f) => ({ ...f, date_of_injury: d ?? "" }))}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/components/trial-edit-cell.tsx
+++ b/frontend/src/pages/cases/components/trial-edit-cell.tsx
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { DatePicker } from "@/components/ui/date-picker"
 import {
   Tooltip,
   TooltipContent,
@@ -162,11 +163,9 @@ export function TrialEditCell({
         <div className="space-y-3">
           <div className="space-y-1">
             <label className="text-xs text-muted-foreground">Trial Date</label>
-            <input
-              type="date"
-              value={draftDate}
-              onChange={(e) => setDraftDate(e.target.value)}
-              className="w-full bg-transparent border border-input px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring"
+            <DatePicker
+              value={draftDate || null}
+              onChange={(d) => setDraftDate(d ?? "")}
             />
           </div>
 

--- a/frontend/src/pages/cases/costs/components/add-advance-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/add-advance-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -121,13 +122,10 @@ export function AddAdvanceDialog({
               />
             </div>
             <div>
-              <Label htmlFor="adv-date">Agreement Date</Label>
-              <Input
-                id="adv-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+              <Label>Agreement Date</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
             <div>

--- a/frontend/src/pages/cases/costs/components/add-invoice-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/add-invoice-dialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -128,22 +129,17 @@ export function AddInvoiceDialog({
               </Select>
             </div>
             <div>
-              <Label htmlFor="add-date">Invoice Date</Label>
-              <Input
-                id="add-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+              <Label>Invoice Date</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
             <div>
-              <Label htmlFor="add-due-date">Due Date</Label>
-              <Input
-                id="add-due-date"
-                type="date"
-                value={dueDate}
-                onChange={(e) => setDueDate(e.target.value)}
+              <Label>Due Date</Label>
+              <DatePicker
+                value={dueDate || null}
+                onChange={(d) => setDueDate(d ?? "")}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/costs/components/add-lien-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/add-lien-dialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -130,12 +131,10 @@ export function AddLienDialog({
               </Select>
             </div>
             <div>
-              <Label htmlFor="lien-date">Date Received</Label>
-              <Input
-                id="lien-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
+              <Label>Date Received</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/costs/components/bulk-invoice-edit-row.tsx
+++ b/frontend/src/pages/cases/costs/components/bulk-invoice-edit-row.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import {
@@ -102,18 +103,16 @@ export function BulkInvoiceEditRow({
             </div>
             <div>
               <Label className="text-xs">Invoice Date</Label>
-              <Input
-                type="date"
-                value={item.date}
-                onChange={(e) => onUpdate({ date: e.target.value })}
+              <DatePicker
+                value={item.date || null}
+                onChange={(d) => onUpdate({ date: d ?? "" })}
               />
             </div>
             <div>
               <Label className="text-xs">Due Date</Label>
-              <Input
-                type="date"
-                value={item.dueDate}
-                onChange={(e) => onUpdate({ dueDate: e.target.value })}
+              <DatePicker
+                value={item.dueDate || null}
+                onChange={(d) => onUpdate({ dueDate: d ?? "" })}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/costs/components/edit-invoice-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/edit-invoice-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -178,23 +179,18 @@ export function EditInvoiceDialog({
               </div>
             )}
             <div>
-              <Label htmlFor="edit-date">{isAdvance ? "Agreement Date" : "Invoice Date"}</Label>
-              <Input
-                id="edit-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+              <Label>{isAdvance ? "Agreement Date" : "Invoice Date"}</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
             {!isAdvance && (
               <div>
-                <Label htmlFor="edit-due-date">Due Date</Label>
-                <Input
-                  id="edit-due-date"
-                  type="date"
-                  value={dueDate}
-                  onChange={(e) => setDueDate(e.target.value)}
+                <Label>Due Date</Label>
+                <DatePicker
+                  value={dueDate || null}
+                  onChange={(d) => setDueDate(d ?? "")}
                 />
               </div>
             )}

--- a/frontend/src/pages/cases/costs/components/edit-lien-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/edit-lien-dialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -134,12 +135,10 @@ export function EditLienDialog({
               </Select>
             </div>
             <div>
-              <Label htmlFor="edit-lien-date">Date Received</Label>
-              <Input
-                id="edit-lien-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
+              <Label>Date Received</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
           </div>
@@ -155,12 +154,10 @@ export function EditLienDialog({
                 />
               </div>
               <div>
-                <Label htmlFor="edit-lien-paid-date">Paid Date</Label>
-                <Input
-                  id="edit-lien-paid-date"
-                  type="date"
-                  value={paidDate}
-                  onChange={(e) => setPaidDate(e.target.value)}
+                <Label>Paid Date</Label>
+                <DatePicker
+                  value={paidDate || null}
+                  onChange={(d) => setPaidDate(d ?? "")}
                 />
               </div>
             </div>

--- a/frontend/src/pages/cases/costs/components/edit-transfer-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/edit-transfer-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Select,
@@ -133,13 +134,10 @@ export function EditTransferDialog({
               </div>
             </div>
             <div>
-              <Label htmlFor="transfer-date">Date</Label>
-              <Input
-                id="transfer-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+              <Label>Date</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/costs/components/invoice-confirm-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/invoice-confirm-dialog.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -128,22 +129,17 @@ export function InvoiceConfirmDialog({
               </Select>
             </div>
             <div>
-              <Label htmlFor="date">Invoice Date</Label>
-              <Input
-                id="date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+              <Label>Invoice Date</Label>
+              <DatePicker
+                value={date || null}
+                onChange={(d) => setDate(d ?? "")}
               />
             </div>
             <div>
-              <Label htmlFor="due_date">Due Date</Label>
-              <Input
-                id="due_date"
-                type="date"
-                value={dueDate}
-                onChange={(e) => setDueDate(e.target.value)}
+              <Label>Due Date</Label>
+              <DatePicker
+                value={dueDate || null}
+                onChange={(d) => setDueDate(d ?? "")}
               />
             </div>
           </div>

--- a/frontend/src/pages/cases/costs/components/mark-paid-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/mark-paid-dialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { type Invoice, markInvoicePaid } from "@/services/invoices"
 
 interface MarkPaidDialogProps {
@@ -82,12 +83,10 @@ export function MarkPaidDialog({
             />
           </div>
           <div className="grid gap-2">
-            <Label htmlFor="paid-date">Date Paid</Label>
-            <Input
-              id="paid-date"
-              type="date"
-              value={paidDate}
-              onChange={(e) => setPaidDate(e.target.value)}
+            <Label>Date Paid</Label>
+            <DatePicker
+              value={paidDate || null}
+              onChange={(d) => setPaidDate(d ?? "")}
             />
           </div>
         </div>

--- a/frontend/src/pages/intakes/components/intake-form-dialog.tsx
+++ b/frontend/src/pages/intakes/components/intake-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Textarea } from "@/components/ui/textarea"
 import { Separator } from "@/components/ui/separator"
 import { extractIntakeFields, type CreateIntakeData } from "@/services/intakes"
@@ -251,12 +252,10 @@ export function IntakeFormDialog({
                 />
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="incident_date">Date</Label>
-                <Input
-                  id="incident_date"
-                  type="date"
-                  value={form.incident_date}
-                  onChange={set("incident_date")}
+                <Label>Date</Label>
+                <DatePicker
+                  value={form.incident_date || null}
+                  onChange={(d) => setForm((f) => ({ ...f, incident_date: d ?? "" }))}
                 />
               </div>
               <div className="grid gap-1.5">

--- a/frontend/src/pages/intakes/components/intake-metadata.tsx
+++ b/frontend/src/pages/intakes/components/intake-metadata.tsx
@@ -5,6 +5,7 @@ import type { Intake } from "@/types/intake"
 import { formatPhone } from "@/lib/utils"
 import { updateIntake } from "@/services/intakes"
 import { Input } from "@/components/ui/input"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Button } from "@/components/ui/button"
 import { SmsLaunchButton } from "@/components/common/sms-launch-button"
 import {
@@ -312,7 +313,10 @@ export function IntakeMetadata({ intake }: IntakeMetadataProps) {
                 </div>
                 <div className="flex items-center gap-2">
                   <HugeiconsIcon icon={Calendar03Icon} className="size-3.5 shrink-0 text-muted-foreground" />
-                  <Input type="date" {...inputProps("incident_date")} />
+                  <DatePicker
+                    value={draft.incident_date || null}
+                    onChange={(d) => setDraft((prev) => ({ ...prev, incident_date: d ?? "" }))}
+                  />
                   <Input placeholder="Time" {...inputProps("incident_time")} className="h-6 w-20 text-xs px-1.5" />
                 </div>
                 <div className="flex items-center gap-2">

--- a/frontend/src/pages/tasks/components/add-task-dialog.tsx
+++ b/frontend/src/pages/tasks/components/add-task-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -110,10 +111,9 @@ export function AddTaskDialog({ open, onOpenChange }: AddTaskDialogProps) {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label className="text-xs">Due Date</Label>
-              <Input
-                type="date"
-                value={dueDate}
-                onChange={(e) => setDueDate(e.target.value)}
+              <DatePicker
+                value={dueDate || null}
+                onChange={(d) => setDueDate(d ?? "")}
               />
             </div>
             <div className="space-y-1.5">

--- a/frontend/src/pages/trial-calendar/components/slot-finder.tsx
+++ b/frontend/src/pages/trial-calendar/components/slot-finder.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { DatePicker } from "@/components/ui/date-picker"
 import { findTrialSlots } from "@/services/trial-calendar"
 
 function parseDate(s: string): Date {
@@ -81,10 +82,9 @@ export function SlotFinder({ open, onOpenChange }: Props) {
             </div>
             <div className="space-y-1.5">
               <Label className="text-xs">Earliest date</Label>
-              <Input
-                type="date"
-                value={earliestDate}
-                onChange={(e) => setEarliestDate(e.target.value)}
+              <DatePicker
+                value={earliestDate || null}
+                onChange={(d) => setEarliestDate(d ?? "")}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Replace all `<input type="date">` and `InlineEditField type="date"` with the existing `DatePicker` component across 18 files
- `InlineEditField` now delegates to `DatePicker` when `type="date"`, fixing 7 inline-edit date fields in one change (case dates, event dates, task detail, financials)
- 21 additional direct swaps across tasks, events, cases, intakes, trial calendar, and all cost/invoice dialogs
- Every date input in the app now supports natural language entry (e.g. "next friday", "in 30 days") backed by chrono-node, plus a calendar popover

## Test plan
- [ ] Tasks: open Add Task dialog, verify DatePicker for due date — type "next friday" and confirm
- [ ] Cases: click Date of Injury or Trial Date on case detail, verify inline DatePicker popover
- [ ] Events: open Add Event dialog on a case, verify date field is DatePicker
- [ ] Intakes: open New Intake form, verify incident date is DatePicker
- [ ] Trial Calendar: open Slot Finder, verify earliest date is DatePicker
- [ ] Costs: open Add Invoice, Edit Invoice, Add Lien, Edit Lien, Mark Paid, Add Advance, Edit Transfer dialogs — all date fields should be DatePicker
- [ ] Verify Escape reverts, Enter commits, calendar click commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)