### PR TITLE
Add advanced N-party cost sharing with settlement calculator

### DIFF
--- a/alembic/versions/274c0f660dad_add_flexible_cost_sharing.py
+++ b/alembic/versions/274c0f660dad_add_flexible_cost_sharing.py
@@ -1,0 +1,35 @@
+"""add flexible cost sharing config and invoice phase_id
+
+Revision ID: 274c0f660dad
+Revises: 737cceef5114
+Create Date: 2026-05-14 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '274c0f660dad'
+down_revision: Union[str, Sequence[str], None] = '737cceef5114'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'cases',
+        sa.Column('cost_sharing_config', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column('invoices', sa.Column('phase_id', sa.Text(), nullable=True))
+    op.create_index('idx_invoices_phase_id', 'invoices', ['phase_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_invoices_phase_id', table_name='invoices')
+    op.drop_column('invoices', 'phase_id')
+    op.drop_column('cases', 'cost_sharing_config')

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -339,6 +339,9 @@ from .invoices import (
     get_cost_sharing,
     set_cost_sharing,
     remove_cost_sharing,
+    set_cost_sharing_config,
+    remove_cost_sharing_config,
+    get_settlement,
     get_advance_stats,
 )
 
@@ -629,6 +632,9 @@ __all__ = [
     "get_cost_sharing",
     "set_cost_sharing",
     "remove_cost_sharing",
+    "set_cost_sharing_config",
+    "remove_cost_sharing_config",
+    "get_settlement",
     "get_advance_stats",
     # Liens
     "list_liens",

--- a/db/cost_sharing.py
+++ b/db/cost_sharing.py
@@ -1,0 +1,340 @@
+"""Pure-function cost-sharing allocator and settlement minimizer.
+
+This module knows nothing about the database. Inputs are plain dicts that the
+caller has already loaded; outputs are plain dicts. Tested as pure logic.
+
+The config shape:
+    {
+      "version": 1,
+      "parties": [{"id": "ours", "label": ...}, {"id": "p:42", "person_id": 42, "label": ...}, ...],
+      "phases": [
+        {
+          "id": "phase-1",
+          "label": "Pre-trial",
+          "boundary_kind": "open_start" | "date",
+          "boundary_date": "2026-09-01" | None,
+          "shares": [{"party": "ours", "pct": 50}, {"party": "p:42", "pct": 50}],
+          "caps": [{"party": "p:42", "max_cumulative": 20000.00}]   # optional
+        },
+        ...
+      ],
+      "absorber_party": "ours"
+    }
+
+Conventions:
+- Party IDs are strings. "ours" is the firm. Person-backed parties use "p:<id>".
+- Phases are ordered by their position in the array. The first phase always
+  has boundary_kind="open_start". Subsequent phases use boundary_kind="date"
+  with a boundary_date. The phase a given invoice belongs to is the latest
+  phase whose boundary_date is <= invoice.date (or the first phase if none).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Iterable, Optional
+
+
+OURS = "ours"
+
+
+def party_id_for_person(person_id: int) -> str:
+    return f"p:{person_id}"
+
+
+def person_id_from_party_id(party_id: str) -> Optional[int]:
+    if party_id.startswith("p:"):
+        try:
+            return int(party_id[2:])
+        except ValueError:
+            return None
+    return None
+
+
+def bucket_invoice(invoice: dict, config: dict) -> str:
+    """Return the phase_id for an invoice. Falls back to the first phase
+    when no date is set on the invoice."""
+    phases = config.get("phases") or []
+    if not phases:
+        return ""
+    inv_date = invoice.get("date")
+    if isinstance(inv_date, str):
+        try:
+            inv_date = datetime.date.fromisoformat(inv_date)
+        except ValueError:
+            inv_date = None
+    if not inv_date:
+        return phases[0]["id"]
+
+    chosen = phases[0]["id"]
+    for phase in phases[1:]:
+        boundary = phase.get("boundary_date")
+        if isinstance(boundary, str):
+            try:
+                boundary = datetime.date.fromisoformat(boundary)
+            except ValueError:
+                continue
+        if not boundary:
+            continue
+        if inv_date >= boundary:
+            chosen = phase["id"]
+        else:
+            break
+    return chosen
+
+
+def _phase_total(phase: dict, invoices: list[dict]) -> float:
+    total = 0.0
+    for inv in invoices:
+        if inv.get("phase_id") != phase["id"]:
+            continue
+        amt = inv.get("case_amount")
+        if amt is None:
+            amt = inv.get("amount", 0)
+        total += float(amt or 0)
+    return total
+
+
+def allocate(config: dict, invoices: list[dict]) -> dict[str, float]:
+    """Compute the target contribution per party.
+
+    `invoices` should already have `phase_id` set (call `bucket_invoice` first
+    if needed). Only cost invoices count — transfers and advances should be
+    filtered out by the caller.
+
+    Returns: {party_id: target_amount}
+    """
+    parties = [p["id"] for p in config.get("parties") or []]
+    if not parties:
+        return {}
+    phases = config.get("phases") or []
+    absorber = config.get("absorber_party") or OURS
+
+    cumulative: dict[str, float] = {p: 0.0 for p in parties}
+
+    # Build a quick lookup of cumulative caps per party (cumulative-across-case)
+    cap_by_party: dict[str, float] = {}
+    cap_absorber_by_party: dict[str, str] = {}
+    for phase in phases:
+        for cap in phase.get("caps") or []:
+            party = cap.get("party")
+            if party not in cumulative:
+                continue
+            amount = float(cap.get("max_cumulative", 0))
+            if party not in cap_by_party or amount < cap_by_party[party]:
+                cap_by_party[party] = amount
+            cap_absorber_by_party[party] = cap.get("absorber") or absorber
+
+    for phase in phases:
+        phase_total = _phase_total(phase, invoices)
+        if phase_total <= 0:
+            continue
+
+        shares = {s["party"]: float(s["pct"]) for s in phase.get("shares") or []}
+        # Initial uncapped allocation
+        phase_alloc: dict[str, float] = {
+            p: phase_total * (shares.get(p, 0.0) / 100.0) for p in parties
+        }
+
+        # Apply caps. Iterate until no party exceeds its cap; usually one pass.
+        for _ in range(len(parties)):
+            spilled = False
+            for party, cap in cap_by_party.items():
+                projected = cumulative[party] + phase_alloc[party]
+                if projected <= cap + 1e-9:
+                    continue
+                overflow = projected - cap
+                phase_alloc[party] -= overflow
+                cap_absorber = cap_absorber_by_party.get(party, absorber)
+                if cap_absorber in phase_alloc:
+                    phase_alloc[cap_absorber] += overflow
+                else:
+                    phase_alloc[absorber] = phase_alloc.get(absorber, 0.0) + overflow
+                spilled = True
+            if not spilled:
+                break
+
+        for party in parties:
+            cumulative[party] += phase_alloc[party]
+
+    return {p: round(cumulative[p], 2) for p in parties}
+
+
+def compute_paid_by_party(invoices: list[dict], parties: list[str]) -> dict[str, float]:
+    """Sum what each party has actually paid (cost invoices only, not transfers)."""
+    paid: dict[str, float] = {p: 0.0 for p in parties}
+    for inv in invoices:
+        if inv.get("is_transfer"):
+            continue
+        if inv.get("type") and inv["type"] != "cost":
+            continue
+        amt = inv.get("case_amount")
+        if amt is None:
+            amt = inv.get("amount", 0)
+        amt = float(amt or 0)
+        paid_by_id = inv.get("paid_by_person_id")
+        if paid_by_id is None:
+            party = OURS
+        else:
+            party = party_id_for_person(int(paid_by_id))
+        if party in paid:
+            paid[party] += amt
+        else:
+            # Payer isn't in the config; bucket under "ours" so the totals
+            # still sum to the case total.
+            paid[OURS] = paid.get(OURS, 0.0) + amt
+    return {p: round(paid[p], 2) for p in paid}
+
+
+def apply_transfers(
+    paid: dict[str, float], invoices: list[dict]
+) -> dict[str, float]:
+    """Adjust per-party paid totals for settlement transfers already on file.
+
+    A transfer where party A pays party B is money out of A's pocket and into
+    B's. So A's effective contribution to the case goes UP by the amount and
+    B's goes DOWN. Returns a copy with adjusted totals.
+    """
+    net = dict(paid)
+    for inv in invoices:
+        if not inv.get("is_transfer"):
+            continue
+        amt = inv.get("case_amount")
+        if amt is None:
+            amt = inv.get("amount", 0)
+        amt = float(amt or 0)
+        paid_by_id = inv.get("paid_by_person_id")
+        transfer_to_id = inv.get("transfer_to_person_id")
+
+        from_party = OURS if paid_by_id is None else party_id_for_person(int(paid_by_id))
+        to_party = OURS if transfer_to_id is None else party_id_for_person(int(transfer_to_id))
+
+        if from_party in net:
+            net[from_party] = round(net[from_party] + amt, 2)
+        if to_party in net:
+            net[to_party] = round(net[to_party] - amt, 2)
+    return net
+
+
+def compute_settlement(deltas: dict[str, float], threshold: float = 0.01) -> list[dict]:
+    """Greedy minimum-transactions settlement.
+
+    Input: {party_id: delta}, where positive delta = overpaid (creditor) and
+    negative = underpaid (debtor). Sum of deltas should be ~0.
+
+    Returns list of {"from_party": ..., "to_party": ..., "amount": ...}.
+    """
+    creditors = sorted(
+        [(p, d) for p, d in deltas.items() if d > threshold],
+        key=lambda x: -x[1],
+    )
+    debtors = sorted(
+        [(p, -d) for p, d in deltas.items() if d < -threshold],
+        key=lambda x: -x[1],
+    )
+
+    transfers: list[dict] = []
+    ci = di = 0
+    while ci < len(creditors) and di < len(debtors):
+        c_party, c_amt = creditors[ci]
+        d_party, d_amt = debtors[di]
+        amount = round(min(c_amt, d_amt), 2)
+        if amount > 0:
+            transfers.append({
+                "from_party": d_party,
+                "to_party": c_party,
+                "amount": amount,
+            })
+        c_amt -= amount
+        d_amt -= amount
+        if c_amt <= threshold:
+            ci += 1
+        else:
+            creditors[ci] = (c_party, c_amt)
+        if d_amt <= threshold:
+            di += 1
+        else:
+            debtors[di] = (d_party, d_amt)
+
+    return transfers
+
+
+def settlement_for_case(
+    config: dict, invoices: list[dict], parties_meta: Optional[dict] = None
+) -> dict:
+    """High-level: given config + invoices (with phase_id), return targets,
+    paid, deltas, and the proposed transfers.
+
+    `parties_meta` optionally maps party_id -> {"label": ..., "person_id": ...}
+    so the result can include human-readable names.
+    """
+    parties = [p["id"] for p in config.get("parties") or []]
+    targets = allocate(config, invoices)
+    paid = compute_paid_by_party(invoices, parties)
+    net = apply_transfers(paid, invoices)
+    deltas = {p: round(net.get(p, 0) - targets.get(p, 0), 2) for p in parties}
+
+    transfers_raw = compute_settlement(deltas)
+    transfers: list[dict] = []
+    for t in transfers_raw:
+        from_meta = (parties_meta or {}).get(t["from_party"]) or {}
+        to_meta = (parties_meta or {}).get(t["to_party"]) or {}
+        transfers.append({
+            "from_party": t["from_party"],
+            "to_party": t["to_party"],
+            "amount": t["amount"],
+            "from_label": from_meta.get("label"),
+            "to_label": to_meta.get("label"),
+            "from_person_id": from_meta.get("person_id"),
+            "to_person_id": to_meta.get("person_id"),
+        })
+
+    return {
+        "parties": parties,
+        "targets": targets,
+        "paid": paid,
+        "net_paid": net,
+        "deltas": deltas,
+        "transfers": transfers,
+    }
+
+
+def materialize_simple_config(
+    partner_person_id: int,
+    partner_label: str,
+    partner_pct: float,
+    partner_organization: Optional[str] = None,
+    our_label: str = "Our Firm",
+) -> dict:
+    """Build a one-phase, two-party config from the legacy simple split.
+
+    Used both when upgrading a case from simple to advanced mode and as a
+    fallback for callers that always want the rich shape.
+    """
+    our_pct = round(100.0 - partner_pct, 2)
+    return {
+        "version": 1,
+        "parties": [
+            {"id": OURS, "label": our_label},
+            {
+                "id": party_id_for_person(partner_person_id),
+                "person_id": partner_person_id,
+                "label": partner_label,
+                "organization": partner_organization,
+            },
+        ],
+        "phases": [
+            {
+                "id": "phase-1",
+                "label": "Default",
+                "boundary_kind": "open_start",
+                "boundary_date": None,
+                "shares": [
+                    {"party": OURS, "pct": our_pct},
+                    {"party": party_id_for_person(partner_person_id), "pct": partner_pct},
+                ],
+                "caps": [],
+            }
+        ],
+        "absorber_party": OURS,
+    }

--- a/db/invoices.py
+++ b/db/invoices.py
@@ -8,7 +8,43 @@ from typing import Optional
 from sqlalchemy import select, func, case as sa_case
 
 from .session import SessionLocal
+from . import cost_sharing as cs
 from models import Invoice, Case, CaseComment, Person, Payee, PersonRole, Role
+
+
+CO_COUNSEL_ROLE_ID = 5
+
+
+def _set_phase_id(session, inv: Invoice) -> None:
+    """If the case has an advanced cost-sharing config, bucket the invoice
+    into the right phase. Otherwise leave phase_id as NULL."""
+    case = session.get(Case, inv.case_id)
+    config = case.cost_sharing_config if case else None
+    if not config:
+        inv.phase_id = None
+        return
+    inv.phase_id = cs.bucket_invoice(
+        {
+            "date": inv.date.isoformat() if inv.date else None,
+        },
+        config,
+    ) or None
+
+
+def _rebucket_case_invoices(session, case_id: int, config: Optional[dict]) -> None:
+    """Recompute phase_id for every invoice on the case. Called when a case's
+    config changes (upgraded to advanced, or a phase boundary moves)."""
+    invs = session.execute(
+        select(Invoice).where(Invoice.case_id == case_id)
+    ).scalars().all()
+    for inv in invs:
+        if not config:
+            inv.phase_id = None
+            continue
+        inv.phase_id = cs.bucket_invoice(
+            {"date": inv.date.isoformat() if inv.date else None},
+            config,
+        ) or None
 
 
 def _invoice_to_dict(
@@ -207,6 +243,7 @@ def create_invoice(
         )
         session.add(inv)
         session.flush()
+        _set_phase_id(session, inv)
 
         case = session.get(Case, case_id)
         case_name = case.case_name if case else None
@@ -259,6 +296,9 @@ def update_invoice(invoice_id: int, **fields) -> Optional[dict]:
             if hasattr(inv, key):
                 setattr(inv, key, value)
         inv.updated_at = datetime.datetime.now(datetime.timezone.utc)
+
+        if "date" in fields:
+            _set_phase_id(session, inv)
 
         session.flush()
         session.refresh(inv)
@@ -441,7 +481,6 @@ def calculate_equalization(case_id: int, our_share_pct: float) -> dict:
             counsel_name = p.name if p else None
 
         if counsel_id is None:
-            CO_COUNSEL_ROLE_ID = 5
             partner_row = session.execute(
                 select(PersonRole, Person)
                 .join(Person, PersonRole.person_id == Person.id)
@@ -517,7 +556,13 @@ def get_invoice_stats(case_id: int = None, type: str = None) -> dict:
 
 
 def get_cost_summary(case_id: int) -> dict:
-    """Net cost breakdown per party, accounting for transfers."""
+    """Net cost breakdown per party, accounting for transfers.
+
+    For simple cases (no advanced config), returns the legacy 2-party shape
+    plus `kind: "simple"`. For advanced cases, additionally returns
+    `parties: [{party_id, label, paid, net, target}]` so the UI can render
+    N parties without recomputing targets locally.
+    """
     effective_amount = func.coalesce(Invoice.case_amount, Invoice.amount)
     with SessionLocal() as session:
         # Actual costs (excluding transfers and advances)
@@ -566,13 +611,12 @@ def get_cost_summary(case_id: int) -> dict:
         our_net = our_costs - net_to_us
         counsel_net = counsel_paid_total + net_to_us
 
-        # Resolve counsel name
+        # Resolve counsel name (legacy shape)
         counsel_id = None
         counsel_name = None
         if counsel_costs:
             counsel_id = next(iter(counsel_costs))
         if counsel_id is None:
-            CO_COUNSEL_ROLE_ID = 5
             partner_row = session.execute(
                 select(PersonRole, Person)
                 .join(Person, PersonRole.person_id == Person.id)
@@ -589,7 +633,8 @@ def get_cost_summary(case_id: int) -> dict:
             p = session.get(Person, counsel_id)
             counsel_name = p.name if p else None
 
-        return {
+        result = {
+            "kind": "simple",
             "total_costs": round(total_costs, 2),
             "our_costs": round(our_costs, 2),
             "counsel_costs": round(counsel_paid_total, 2),
@@ -600,10 +645,73 @@ def get_cost_summary(case_id: int) -> dict:
             "counsel_name": counsel_name,
         }
 
+        # Advanced mode: enrich with per-party breakdown.
+        case = session.get(Case, case_id)
+        config = case.cost_sharing_config if case else None
+        if config:
+            invoices = _load_case_invoices_for_allocation(session, case_id)
+            settlement = cs.settlement_for_case(
+                config, invoices, _parties_meta_from_config(config)
+            )
+            parties_meta = _parties_meta_from_config(config)
+            party_breakdown = []
+            for pid in settlement["parties"]:
+                meta = parties_meta.get(pid, {})
+                party_breakdown.append({
+                    "party_id": pid,
+                    "label": meta.get("label"),
+                    "person_id": meta.get("person_id"),
+                    "paid": settlement["paid"].get(pid, 0),
+                    "net_paid": settlement["net_paid"].get(pid, 0),
+                    "target": settlement["targets"].get(pid, 0),
+                })
+            result["kind"] = "advanced"
+            result["parties"] = party_breakdown
+            result["targets_by_party"] = settlement["targets"]
+        return result
+
+
+def _parties_meta_from_config(config: dict) -> dict:
+    """party_id -> {label, person_id, organization}"""
+    out = {}
+    for p in config.get("parties") or []:
+        out[p["id"]] = {
+            "label": p.get("label"),
+            "person_id": p.get("person_id"),
+            "organization": p.get("organization"),
+        }
+    return out
+
+
+def _load_case_invoices_for_allocation(session, case_id: int) -> list[dict]:
+    """Minimal invoice projection for the pure allocator."""
+    rows = session.execute(
+        select(Invoice).where(Invoice.case_id == case_id)
+    ).scalars().all()
+    return [
+        {
+            "id": inv.id,
+            "amount": float(inv.amount) if inv.amount is not None else 0,
+            "case_amount": float(inv.case_amount) if inv.case_amount is not None else None,
+            "date": inv.date.isoformat() if inv.date else None,
+            "paid_by_person_id": inv.paid_by_person_id,
+            "transfer_to_person_id": inv.transfer_to_person_id,
+            "type": inv.type,
+            "is_transfer": bool(inv.is_transfer),
+            "phase_id": inv.phase_id,
+        }
+        for inv in rows
+    ]
+
 
 def get_cost_sharing(case_id: int) -> dict:
-    """Get cost-sharing config for a case: the designated partner and split percentage."""
-    CO_COUNSEL_ROLE_ID = 5
+    """Get cost-sharing config for a case.
+
+    Returns a discriminated shape:
+    - {kind: "simple", co_counsel, partner, our_pct} — legacy, when no JSONB config.
+    - {kind: "advanced", config, parties_with_pct: [{party_id, label, person_id, pct}],
+       absorber_party} — when the case has been upgraded.
+    """
     with SessionLocal() as session:
         rows = session.execute(
             select(PersonRole, Person)
@@ -628,8 +736,35 @@ def get_cost_sharing(case_id: int) -> dict:
             if pr.cost_share_pct is not None:
                 partner = entry
 
+        case = session.get(Case, case_id)
+        config = case.cost_sharing_config if case else None
+
+        if config:
+            # Advanced mode. Derive a flat parties_with_pct from the first
+            # phase (Slice 1 only supports one phase).
+            phases = config.get("phases") or []
+            first_phase = phases[0] if phases else {}
+            shares_by_party = {s["party"]: float(s["pct"]) for s in first_phase.get("shares") or []}
+            parties_with_pct = []
+            for p in config.get("parties") or []:
+                parties_with_pct.append({
+                    "party_id": p["id"],
+                    "label": p.get("label"),
+                    "person_id": p.get("person_id"),
+                    "organization": p.get("organization"),
+                    "pct": shares_by_party.get(p["id"], 0),
+                })
+            return {
+                "kind": "advanced",
+                "co_counsel": co_counsel,  # included so the picker still works
+                "config": config,
+                "parties_with_pct": parties_with_pct,
+                "absorber_party": config.get("absorber_party") or cs.OURS,
+            }
+
         our_pct = (100.0 - partner["cost_share_pct"]) if partner else None
         return {
+            "kind": "simple",
             "co_counsel": co_counsel,
             "partner": partner,
             "our_pct": our_pct,
@@ -640,9 +775,17 @@ def set_cost_sharing(case_id: int, person_id: int, cost_share_pct: float) -> dic
     """Designate a co-counsel as the cost-sharing partner with their share percentage.
 
     Auto-assigns the person as co-counsel on the case if they aren't already.
+    If the case is in advanced mode, this raises — callers must use
+    `set_cost_sharing_config` instead.
     """
-    CO_COUNSEL_ROLE_ID = 5
     with SessionLocal() as session:
+        case = session.get(Case, case_id)
+        if case and case.cost_sharing_config:
+            raise ValueError(
+                "Case is in advanced cost-sharing mode. "
+                "Use the advanced config endpoint or reset to simple first."
+            )
+
         all_pr = session.execute(
             select(PersonRole).where(
                 PersonRole.case_id == case_id,
@@ -678,6 +821,10 @@ def remove_cost_sharing(case_id: int) -> dict:
     Returns {"success": True} or raises ValueError.
     """
     config = get_cost_sharing(case_id)
+    if config.get("kind") == "advanced":
+        raise ValueError(
+            "Case is in advanced cost-sharing mode. Reset to simple first."
+        )
     partner = config.get("partner")
     if not partner:
         raise ValueError("No cost-sharing partner to remove")
@@ -698,7 +845,6 @@ def remove_cost_sharing(case_id: int) -> dict:
                 f"{partner['name']} is involved in {involved} invoice(s) on this case and cannot be removed"
             )
 
-        CO_COUNSEL_ROLE_ID = 5
         prs = session.execute(
             select(PersonRole).where(
                 PersonRole.case_id == case_id,
@@ -712,6 +858,174 @@ def remove_cost_sharing(case_id: int) -> dict:
 
         session.commit()
         return {"success": True}
+
+
+def set_cost_sharing_config(case_id: int, config: dict) -> dict:
+    """Write the JSONB cost-sharing config for a case.
+
+    Side effects:
+    - Clears `PersonRole.cost_share_pct` for all co-counsel on this case
+      (so the JSONB is the single source of truth).
+    - Auto-assigns each person-backed party as co-counsel on the case if
+      they aren't already.
+    - Re-buckets every invoice on the case so `phase_id` matches the new config.
+
+    The caller is responsible for validating `config` (use Pydantic).
+    """
+    with SessionLocal() as session:
+        case = session.get(Case, case_id)
+        if not case:
+            raise ValueError(f"Case {case_id} not found")
+
+        # Auto-assign person-backed parties as co-counsel on the case.
+        existing_pr = session.execute(
+            select(PersonRole).where(
+                PersonRole.case_id == case_id,
+                PersonRole.role_id == CO_COUNSEL_ROLE_ID,
+            )
+        ).scalars().all()
+        existing_by_person = {pr.person_id: pr for pr in existing_pr}
+        # Clear legacy cost_share_pct on every co-counsel — JSONB is now SoT.
+        for pr in existing_pr:
+            pr.cost_share_pct = None
+
+        for party in config.get("parties") or []:
+            pid = party.get("person_id")
+            if pid is None:
+                continue
+            if pid not in existing_by_person:
+                session.add(PersonRole(
+                    person_id=pid,
+                    role_id=CO_COUNSEL_ROLE_ID,
+                    case_id=case_id,
+                ))
+
+        case.cost_sharing_config = config
+        session.flush()
+        _rebucket_case_invoices(session, case_id, config)
+        session.commit()
+
+    return get_cost_sharing(case_id)
+
+
+def remove_cost_sharing_config(case_id: int) -> dict:
+    """Reset a case from advanced mode back to simple.
+
+    If the config has exactly one non-ours party, restore that party's
+    PersonRole.cost_share_pct so the simple UI continues showing the same
+    split. Otherwise just clear the config (the simple UI will show
+    "Set up split").
+    """
+    with SessionLocal() as session:
+        case = session.get(Case, case_id)
+        if not case:
+            raise ValueError(f"Case {case_id} not found")
+
+        config = case.cost_sharing_config
+        if not config:
+            return get_cost_sharing(case_id)
+
+        # Try to restore a simple split if the config is representable as one.
+        non_ours = [p for p in config.get("parties") or [] if p.get("person_id")]
+        if len(non_ours) == 1:
+            party = non_ours[0]
+            phases = config.get("phases") or []
+            if phases:
+                shares = {s["party"]: float(s["pct"]) for s in phases[0].get("shares") or []}
+                pct = shares.get(party["id"])
+                if pct is not None:
+                    pr = session.execute(
+                        select(PersonRole).where(
+                            PersonRole.case_id == case_id,
+                            PersonRole.role_id == CO_COUNSEL_ROLE_ID,
+                            PersonRole.person_id == party["person_id"],
+                        )
+                    ).scalar_one_or_none()
+                    if pr:
+                        pr.cost_share_pct = pct
+                    else:
+                        session.add(PersonRole(
+                            person_id=party["person_id"],
+                            role_id=CO_COUNSEL_ROLE_ID,
+                            case_id=case_id,
+                            cost_share_pct=pct,
+                        ))
+
+        case.cost_sharing_config = None
+        session.flush()
+        _rebucket_case_invoices(session, case_id, None)
+        session.commit()
+
+    return get_cost_sharing(case_id)
+
+
+def get_settlement(case_id: int) -> dict:
+    """Return the proposed settlement transfers for a case.
+
+    Works for both simple and advanced configs. For simple cases, builds an
+    in-memory advanced config from the legacy partner+pct so the same
+    allocator/settlement logic can run.
+    """
+    with SessionLocal() as session:
+        case = session.get(Case, case_id)
+        if not case:
+            raise ValueError(f"Case {case_id} not found")
+
+        config = case.cost_sharing_config
+        if not config:
+            # Build a one-phase config from the legacy partner.
+            partner_row = session.execute(
+                select(PersonRole, Person)
+                .join(Person, PersonRole.person_id == Person.id)
+                .where(
+                    PersonRole.case_id == case_id,
+                    PersonRole.role_id == CO_COUNSEL_ROLE_ID,
+                    PersonRole.cost_share_pct.isnot(None),
+                )
+            ).first()
+            if not partner_row:
+                return {
+                    "kind": "simple",
+                    "parties": [],
+                    "targets": {},
+                    "paid": {},
+                    "net_paid": {},
+                    "deltas": {},
+                    "transfers": [],
+                }
+            pr, person = partner_row
+            config = cs.materialize_simple_config(
+                partner_person_id=person.id,
+                partner_label=person.name,
+                partner_pct=float(pr.cost_share_pct),
+                partner_organization=person.organization,
+            )
+            kind = "simple"
+        else:
+            kind = "advanced"
+
+        invoices = _load_case_invoices_for_allocation(session, case_id)
+        # If a simple case never had phase_id set, the bucket lookup will
+        # naturally fall back to phase-1, but be explicit:
+        for inv in invoices:
+            if not inv.get("phase_id"):
+                inv["phase_id"] = cs.bucket_invoice(inv, config)
+
+        parties_meta = _parties_meta_from_config(config)
+        result = cs.settlement_for_case(config, invoices, parties_meta)
+        result["kind"] = kind
+        result["config"] = config
+        # Enrich parties array with metadata for UI.
+        result["parties_meta"] = [
+            {
+                "party_id": pid,
+                "label": parties_meta.get(pid, {}).get("label"),
+                "person_id": parties_meta.get(pid, {}).get("person_id"),
+                "organization": parties_meta.get(pid, {}).get("organization"),
+            }
+            for pid in result["parties"]
+        ]
+        return result
 
 
 def get_advance_stats(case_id: int) -> dict:

--- a/frontend/src/pages/cases/costs/components/cost-sharing-bar.tsx
+++ b/frontend/src/pages/cases/costs/components/cost-sharing-bar.tsx
@@ -6,6 +6,10 @@ import {
   getCostSharing,
   setCostSharing,
   removeCostSharing,
+  setCostSharingConfig,
+  removeCostSharingConfig,
+  type AdvancedConfig,
+  type AdvancedParty,
 } from "@/services/invoices"
 import {
   searchPersons,
@@ -20,6 +24,16 @@ interface CostSharingBarProps {
   onEditingChange?: (editing: boolean) => void
 }
 
+type AdvancedPartyDraft = AdvancedParty & {
+  pct: number
+}
+
+const OURS = "ours"
+
+function partyIdForPerson(personId: number): string {
+  return `p:${personId}`
+}
+
 export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }: CostSharingBarProps) {
   const queryClient = useQueryClient()
   const [internalEditing, setInternalEditing] = useState(false)
@@ -27,11 +41,15 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
   const [saving, setSaving] = useState(false)
   const [removing, setRemoving] = useState(false)
 
-  // Person selection state
+  // Person selection state (simple editor)
   const [search, setSearch] = useState("")
-  const [selectedPerson, setSelectedPerson] = useState<{ id: number; name: string } | null>(null)
+  const [selectedPerson, setSelectedPerson] = useState<{ id: number; name: string; organization?: string | null } | null>(null)
   const [mode, setMode] = useState<"pick" | "create">("pick")
   const [newName, setNewName] = useState("")
+
+  // Advanced editor state
+  const [advancedMode, setAdvancedMode] = useState(false)
+  const [advancedParties, setAdvancedParties] = useState<AdvancedPartyDraft[]>([])
 
   const debouncedSearch = useDebounce(search, 300)
 
@@ -49,14 +67,28 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
   const { data: searchResults } = useQuery({
     queryKey: ["person-search", debouncedSearch],
     queryFn: () => searchPersons({ name: debouncedSearch, limit: 10 }),
-    enabled: editing && mode === "pick" && debouncedSearch.length >= 2,
+    enabled: editing && !advancedMode && mode === "pick" && debouncedSearch.length >= 2,
   })
 
+  // Initialize state when entering edit mode.
   useEffect(() => {
-    if (editingProp && data) {
+    if (!editing || !data) return
+    if (data.kind === "advanced") {
+      setAdvancedMode(true)
+      setAdvancedParties(
+        data.parties_with_pct.map((p) => ({
+          id: p.party_id,
+          label: p.label,
+          person_id: p.person_id,
+          organization: p.organization,
+          pct: p.pct,
+        }))
+      )
+    } else {
+      setAdvancedMode(false)
       const partner = data.partner
       if (partner) {
-        setSelectedPerson({ id: partner.person_id, name: partner.name })
+        setSelectedPerson({ id: partner.person_id, name: partner.name, organization: partner.organization })
         setTheirPct(partner.cost_share_pct != null ? String(partner.cost_share_pct) : "50")
       } else {
         setSelectedPerson(null)
@@ -66,29 +98,17 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
       setMode("pick")
       setNewName("")
     }
-  }, [editingProp, data])
+  }, [editing, data])
 
-  if (isLoading || !data) return null
-
-  const partner = data.partner
-  const ourPct = data.our_pct
-  const coCounsel = data.co_counsel
-
-  function startEditing() {
-    if (partner) {
-      setSelectedPerson({ id: partner.person_id, name: partner.name })
-      setTheirPct(partner.cost_share_pct != null ? String(partner.cost_share_pct) : "50")
-    } else {
-      setSelectedPerson(null)
-      setTheirPct("50")
-    }
-    setSearch("")
-    setMode("pick")
-    setNewName("")
-    setEditing(true)
+  function invalidateAfterChange() {
+    queryClient.invalidateQueries({ queryKey: ["cost-sharing", caseId] })
+    queryClient.invalidateQueries({ queryKey: ["equalization"] })
+    queryClient.invalidateQueries({ queryKey: ["cost-summary", caseId] })
+    queryClient.invalidateQueries({ queryKey: ["settlement", caseId] })
+    queryClient.invalidateQueries({ queryKey: ["case", caseId] })
   }
 
-  async function handleSave() {
+  async function handleSaveSimple() {
     let personId = selectedPerson?.id
     if (mode === "create" && newName.trim()) {
       setSaving(true)
@@ -105,10 +125,7 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
     setSaving(true)
     try {
       await setCostSharing(caseId, personId, parseFloat(theirPct) || 50)
-      queryClient.invalidateQueries({ queryKey: ["cost-sharing", caseId] })
-      queryClient.invalidateQueries({ queryKey: ["equalization"] })
-      queryClient.invalidateQueries({ queryKey: ["cost-summary", caseId] })
-      queryClient.invalidateQueries({ queryKey: ["case", caseId] })
+      invalidateAfterChange()
       toast.success("Cost sharing updated")
       setEditing(false)
     } catch {
@@ -118,22 +135,148 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
     }
   }
 
-  const canSave = mode === "create"
-    ? newName.trim().length > 0
-    : selectedPerson != null
+  function startEditing() {
+    if (!data) return
+    if (data.kind === "advanced") {
+      setAdvancedMode(true)
+      setAdvancedParties(
+        data.parties_with_pct.map((p) => ({
+          id: p.party_id,
+          label: p.label,
+          person_id: p.person_id,
+          organization: p.organization,
+          pct: p.pct,
+        }))
+      )
+    } else {
+      setAdvancedMode(false)
+      const partner = data.partner
+      if (partner) {
+        setSelectedPerson({ id: partner.person_id, name: partner.name, organization: partner.organization })
+        setTheirPct(partner.cost_share_pct != null ? String(partner.cost_share_pct) : "50")
+      } else {
+        setSelectedPerson(null)
+        setTheirPct("50")
+      }
+      setSearch("")
+      setMode("pick")
+      setNewName("")
+    }
+    setEditing(true)
+  }
 
-  const searchPersons_ = searchResults?.persons ?? []
-  const coCounselIds = new Set(coCounsel.map((c) => c.person_id))
+  async function handleRemove() {
+    if (!data) return
+    if (data.kind === "advanced") {
+      if (!confirm("Reset cost sharing to simple? This will clear the advanced configuration.")) return
+      setRemoving(true)
+      try {
+        await removeCostSharingConfig(caseId)
+        invalidateAfterChange()
+        toast.success("Cost sharing reset")
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to reset cost sharing")
+      } finally {
+        setRemoving(false)
+      }
+      return
+    }
+    const partnerName = data.partner?.name ?? ""
+    if (!confirm(`Remove cost sharing with ${partnerName}?`)) return
+    setRemoving(true)
+    try {
+      await removeCostSharing(caseId)
+      invalidateAfterChange()
+      toast.success("Cost sharing removed")
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to remove cost sharing")
+    } finally {
+      setRemoving(false)
+    }
+  }
 
-  // Split results: co-counsel on case first, then others
-  const coCounselResults = coCounsel.filter(
-    (c) => !search || c.name.toLowerCase().includes(search.toLowerCase())
-  )
-  const otherResults = searchPersons_.filter(
-    (p) => !coCounselIds.has(p.id)
-  )
+  // Switch from simple editor to advanced — seed the advanced editor with
+  // whatever's currently in the simple form.
+  function enterAdvancedMode() {
+    const parties: AdvancedPartyDraft[] = [
+      { id: OURS, label: "Our Firm", person_id: null, pct: 100 - (parseFloat(theirPct) || 50) },
+    ]
+    if (selectedPerson) {
+      parties.push({
+        id: partyIdForPerson(selectedPerson.id),
+        label: selectedPerson.name,
+        person_id: selectedPerson.id,
+        organization: selectedPerson.organization ?? null,
+        pct: parseFloat(theirPct) || 50,
+      })
+    }
+    setAdvancedParties(parties)
+    setAdvancedMode(true)
+  }
 
+  if (isLoading || !data) return null
+
+  // ---------- Edit mode (advanced) ----------
+  if (editing && advancedMode) {
+    return (
+      <AdvancedEditor
+        caseId={caseId}
+        parties={advancedParties}
+        onPartiesChange={setAdvancedParties}
+        coCounselSuggestions={data.co_counsel}
+        saving={saving}
+        onSave={async (parties) => {
+          setSaving(true)
+          try {
+            const config: AdvancedConfig = {
+              version: 1,
+              parties: parties.map((p) => ({
+                id: p.id,
+                label: p.label,
+                person_id: p.person_id ?? null,
+                organization: p.organization ?? null,
+              })),
+              phases: [
+                {
+                  id: "phase-1",
+                  label: "Default",
+                  boundary_kind: "open_start",
+                  boundary_date: null,
+                  shares: parties.map((p) => ({ party: p.id, pct: p.pct })),
+                  caps: [],
+                },
+              ],
+              absorber_party: OURS,
+            }
+            await setCostSharingConfig(caseId, config)
+            invalidateAfterChange()
+            toast.success("Cost sharing updated")
+            setEditing(false)
+          } catch (e) {
+            toast.error(e instanceof Error ? e.message : "Failed to save cost sharing")
+          } finally {
+            setSaving(false)
+          }
+        }}
+        onCancel={() => setEditing(false)}
+      />
+    )
+  }
+
+  // ---------- Edit mode (simple) ----------
   if (editing) {
+    const searchPersons_ = searchResults?.persons ?? []
+    const coCounsel = data.kind === "simple" ? data.co_counsel : []
+    const coCounselIds = new Set(coCounsel.map((c) => c.person_id))
+    const coCounselResults = coCounsel.filter(
+      (c) => !search || c.name.toLowerCase().includes(search.toLowerCase())
+    )
+    const otherResults = searchPersons_.filter((p) => !coCounselIds.has(p.id))
+
+    const canSave = mode === "create"
+      ? newName.trim().length > 0
+      : selectedPerson != null
+
     return (
       <div className="flex flex-col gap-3 border border-dashed p-3 text-sm">
         <div className="flex items-center gap-3">
@@ -200,6 +343,13 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
           )}
 
           <div className="flex items-center gap-1 ml-auto">
+            <button
+              type="button"
+              onClick={enterAdvancedMode}
+              className="text-xs text-muted-foreground hover:text-foreground underline mr-2"
+            >
+              Advanced...
+            </button>
             <Button
               variant="outline"
               size="sm"
@@ -211,7 +361,7 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
             <Button
               size="sm"
               className="h-7 text-xs"
-              onClick={handleSave}
+              onClick={handleSaveSimple}
               disabled={saving || !canSave}
             >
               {saving ? "Saving..." : "Save"}
@@ -232,7 +382,7 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
                     key={c.person_id}
                     type="button"
                     onClick={() => {
-                      setSelectedPerson({ id: c.person_id, name: c.name })
+                      setSelectedPerson({ id: c.person_id, name: c.name, organization: c.organization })
                       setTheirPct(c.cost_share_pct != null ? String(c.cost_share_pct) : "50")
                     }}
                     className="flex items-center justify-between w-full px-3 py-2 text-xs hover:bg-accent transition-colors"
@@ -254,7 +404,7 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
                   <button
                     key={p.id}
                     type="button"
-                    onClick={() => setSelectedPerson({ id: p.id, name: p.name })}
+                    onClick={() => setSelectedPerson({ id: p.id, name: p.name, organization: p.organization })}
                     className="flex items-center justify-between w-full px-3 py-2 text-xs hover:bg-accent transition-colors"
                   >
                     <span className="font-medium">{p.name}</span>
@@ -286,22 +436,39 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
     )
   }
 
-  async function handleRemove() {
-    if (!confirm(`Remove cost sharing with ${partner?.name}?`)) return
-    setRemoving(true)
-    try {
-      await removeCostSharing(caseId)
-      queryClient.invalidateQueries({ queryKey: ["cost-sharing", caseId] })
-      queryClient.invalidateQueries({ queryKey: ["cost-summary", caseId] })
-      queryClient.invalidateQueries({ queryKey: ["case", caseId] })
-      toast.success("Cost sharing removed")
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to remove cost sharing")
-    } finally {
-      setRemoving(false)
-    }
+  // ---------- View mode (advanced) ----------
+  if (data.kind === "advanced") {
+    return (
+      <div className="flex items-center gap-3 border p-3 text-sm flex-wrap">
+        <span className="text-muted-foreground">Cost split:</span>
+        {data.parties_with_pct.map((p, idx) => (
+          <span key={p.party_id} className="flex items-center gap-1">
+            {idx > 0 && <span className="text-muted-foreground mr-2">/</span>}
+            <span className="font-medium">{p.label} {p.pct}%</span>
+          </span>
+        ))}
+        <div className="flex items-center gap-2 ml-auto">
+          <button
+            onClick={startEditing}
+            className="text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            Edit
+          </button>
+          <button
+            onClick={handleRemove}
+            disabled={removing}
+            className="text-xs text-muted-foreground hover:text-destructive underline disabled:opacity-50"
+          >
+            {removing ? "Resetting..." : "Reset to simple"}
+          </button>
+        </div>
+      </div>
+    )
   }
 
+  // ---------- View mode (simple) ----------
+  const partner = data.partner
+  const ourPct = data.our_pct
   if (!partner) return null
 
   return (
@@ -329,6 +496,297 @@ export function CostSharingBar({ caseId, editing: editingProp, onEditingChange }
           {removing ? "Removing..." : "Remove"}
         </button>
       </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Advanced editor — N parties + per-party percent rows.
+// Slice 1: parties only. Phases / caps come in later slices.
+// ---------------------------------------------------------------------------
+
+function AdvancedEditor({
+  parties,
+  onPartiesChange,
+  coCounselSuggestions,
+  saving,
+  onSave,
+  onCancel,
+}: {
+  caseId: number
+  parties: AdvancedPartyDraft[]
+  onPartiesChange: (parties: AdvancedPartyDraft[]) => void
+  coCounselSuggestions: { person_id: number; name: string; organization: string | null }[]
+  saving: boolean
+  onSave: (parties: AdvancedPartyDraft[]) => Promise<void>
+  onCancel: () => void
+}) {
+  const [search, setSearch] = useState("")
+  const [pickerOpenForRow, setPickerOpenForRow] = useState<number | null>(null)
+  const [createMode, setCreateMode] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [creating, setCreating] = useState(false)
+
+  const debouncedSearch = useDebounce(search, 300)
+  const { data: searchResults } = useQuery({
+    queryKey: ["person-search-advanced", debouncedSearch],
+    queryFn: () => searchPersons({ name: debouncedSearch, limit: 10 }),
+    enabled: pickerOpenForRow != null && !createMode && debouncedSearch.length >= 2,
+  })
+
+  const total = parties.reduce((sum, p) => sum + (Number.isFinite(p.pct) ? p.pct : 0), 0)
+  const totalOk = Math.abs(total - 100) < 0.01
+  const personPartyIds = new Set(parties.map((p) => p.id))
+
+  function updatePartyPct(idx: number, pct: number) {
+    const next = [...parties]
+    next[idx] = { ...next[idx], pct }
+    onPartiesChange(next)
+  }
+
+  function removeParty(idx: number) {
+    if (parties[idx].id === OURS) return
+    const next = parties.filter((_, i) => i !== idx)
+    onPartiesChange(next)
+  }
+
+  function addEmptyPartySlot() {
+    setPickerOpenForRow(parties.length)
+    setSearch("")
+    setCreateMode(false)
+    setNewName("")
+  }
+
+  async function pickPerson(p: { id: number; name: string; organization?: string | null }) {
+    if (pickerOpenForRow == null) return
+    const partyId = partyIdForPerson(p.id)
+    if (personPartyIds.has(partyId)) {
+      toast.error("That person is already a party")
+      return
+    }
+    const next = [...parties]
+    if (pickerOpenForRow >= parties.length) {
+      next.push({
+        id: partyId,
+        label: p.name,
+        person_id: p.id,
+        organization: p.organization ?? null,
+        pct: 0,
+      })
+    } else {
+      next[pickerOpenForRow] = {
+        ...next[pickerOpenForRow],
+        id: partyId,
+        label: p.name,
+        person_id: p.id,
+        organization: p.organization ?? null,
+      }
+    }
+    onPartiesChange(next)
+    setPickerOpenForRow(null)
+  }
+
+  async function createAndPick() {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      const result = await createPerson({ name: newName.trim() })
+      await pickPerson({ id: result.person.id, name: result.person.name, organization: null })
+      setCreateMode(false)
+      setNewName("")
+    } catch {
+      toast.error("Failed to create person")
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const filteredSuggestions = coCounselSuggestions.filter(
+    (c) => !personPartyIds.has(partyIdForPerson(c.person_id))
+  ).filter(
+    (c) => !search || c.name.toLowerCase().includes(search.toLowerCase())
+  )
+  const filteredOthers = (searchResults?.persons ?? []).filter(
+    (p) => !personPartyIds.has(partyIdForPerson(p.id))
+      && !filteredSuggestions.some((c) => c.person_id === p.id)
+  )
+
+  return (
+    <div className="flex flex-col gap-3 border border-dashed p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground">Cost-sharing parties (advanced)</span>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onSave(parties)}
+            disabled={saving || !totalOk || parties.length < 2}
+          >
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {parties.map((p, idx) => (
+          <div key={`${p.id}-${idx}`} className="flex items-center gap-2">
+            <span className="font-medium w-[200px] truncate">{p.label}</span>
+            <Input
+              type="number"
+              min="0"
+              max="100"
+              step="0.01"
+              value={p.pct}
+              onChange={(e) => updatePartyPct(idx, parseFloat(e.target.value) || 0)}
+              className="w-[80px] h-8 text-sm text-center"
+            />
+            <span className="text-muted-foreground shrink-0">%</span>
+            {p.id !== OURS && (
+              <button
+                type="button"
+                onClick={() => removeParty(idx)}
+                className="text-xs text-muted-foreground hover:text-destructive underline ml-1"
+              >
+                remove
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Total + add button */}
+      <div className="flex items-center justify-between border-t pt-2">
+        <div className="text-xs">
+          <span className="text-muted-foreground">Total:</span>{" "}
+          <span className={totalOk ? "font-medium" : "font-medium text-destructive"}>
+            {total.toFixed(2)}%
+          </span>
+          {!totalOk && (
+            <span className="ml-2 text-destructive">must equal 100%</span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={addEmptyPartySlot}
+          className="text-xs text-muted-foreground hover:text-foreground underline"
+        >
+          + Add co-counsel
+        </button>
+      </div>
+
+      {/* Picker for the new row */}
+      {pickerOpenForRow != null && (
+        <div className="flex flex-col gap-2 border p-2">
+          <div className="flex items-center gap-2">
+            {createMode ? (
+              <>
+                <Input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Full name..."
+                  className="h-8 text-sm flex-1"
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  onClick={() => setCreateMode(false)}
+                  className="text-xs text-muted-foreground hover:text-foreground underline shrink-0"
+                >
+                  Search
+                </button>
+                <Button
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={createAndPick}
+                  disabled={creating || !newName.trim()}
+                >
+                  {creating ? "Adding..." : "Add"}
+                </Button>
+              </>
+            ) : (
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by name..."
+                className="h-8 text-sm flex-1"
+                autoFocus
+              />
+            )}
+            <button
+              type="button"
+              onClick={() => {
+                setPickerOpenForRow(null)
+                setSearch("")
+              }}
+              className="text-xs text-muted-foreground hover:text-foreground underline shrink-0"
+            >
+              cancel
+            </button>
+          </div>
+          {!createMode && (
+            <div className="max-h-40 overflow-y-auto border divide-y">
+              {filteredSuggestions.length > 0 && (
+                <>
+                  <div className="px-3 py-1 text-xs text-muted-foreground bg-muted/50">
+                    Co-counsel on case
+                  </div>
+                  {filteredSuggestions.map((c) => (
+                    <button
+                      key={c.person_id}
+                      type="button"
+                      onClick={() => pickPerson({ id: c.person_id, name: c.name, organization: c.organization })}
+                      className="flex items-center justify-between w-full px-3 py-2 text-xs hover:bg-accent"
+                    >
+                      <span className="font-medium">{c.name}</span>
+                      {c.organization && (
+                        <span className="text-muted-foreground">{c.organization}</span>
+                      )}
+                    </button>
+                  ))}
+                </>
+              )}
+              {filteredOthers.length > 0 && (
+                <>
+                  <div className="px-3 py-1 text-xs text-muted-foreground bg-muted/50">
+                    Other contacts
+                  </div>
+                  {filteredOthers.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => pickPerson({ id: p.id, name: p.name, organization: p.organization })}
+                      className="flex items-center justify-between w-full px-3 py-2 text-xs hover:bg-accent"
+                    >
+                      <span className="font-medium">{p.name}</span>
+                      {p.organization && (
+                        <span className="text-muted-foreground">{p.organization}</span>
+                      )}
+                    </button>
+                  ))}
+                </>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setCreateMode(true)
+                  setNewName(search)
+                }}
+                className="w-full px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-accent text-left"
+              >
+                + Create new person
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/cases/costs/components/edit-invoice-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/edit-invoice-dialog.tsx
@@ -63,7 +63,13 @@ export function EditInvoiceDialog({
     queryFn: () => getCostSharing(invoice!.case_id),
     enabled: !!invoice?.case_id,
   })
-  const costShareCounsel = costSharing?.co_counsel.filter((c) => c.cost_share_pct != null) ?? []
+  // Who can be selected as "Paid by"? In simple mode, the active cost-share
+  // partner. In advanced mode, every non-ours party.
+  const costShareCounsel = costSharing?.kind === "advanced"
+    ? costSharing.parties_with_pct
+        .filter((p) => p.person_id != null)
+        .map((p) => ({ person_id: p.person_id as number, name: p.label, organization: p.organization, cost_share_pct: p.pct }))
+    : costSharing?.co_counsel.filter((c) => c.cost_share_pct != null) ?? []
 
   const { data: casePersons } = useQuery({
     queryKey: ["case-persons", invoice?.case_id],

--- a/frontend/src/pages/cases/costs/components/edit-transfer-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/edit-transfer-dialog.tsx
@@ -48,8 +48,24 @@ export function EditTransferDialog({
     enabled: !!invoice?.case_id,
   })
 
-  const partnerName = costSharing?.partner?.name ?? "Co-counsel"
-  const counselId = costSharing?.partner?.person_id ?? null
+  // The "other party" for a transfer. In simple mode, the configured partner.
+  // In advanced mode, derive from the existing transfer's payer/recipient if
+  // present, falling back to the first non-ours party.
+  let partnerName = "Co-counsel"
+  let counselId: number | null = null
+  if (costSharing?.kind === "simple") {
+    partnerName = costSharing.partner?.name ?? "Co-counsel"
+    counselId = costSharing.partner?.person_id ?? null
+  } else if (costSharing?.kind === "advanced") {
+    const counterpartyId = invoice?.paid_by_person_id ?? invoice?.transfer_to_person_id ?? null
+    const match = costSharing.parties_with_pct.find(
+      (p) => p.person_id != null && (counterpartyId == null || p.person_id === counterpartyId)
+    )
+    if (match?.person_id != null) {
+      counselId = match.person_id
+      partnerName = match.label
+    }
+  }
 
   useEffect(() => {
     if (invoice) {

--- a/frontend/src/pages/cases/costs/components/equalization-dialog.tsx
+++ b/frontend/src/pages/cases/costs/components/equalization-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Select,
   SelectContent,
@@ -22,6 +23,8 @@ import {
   calculateEqualization,
   createInvoice,
   getCostSharing,
+  getSettlement,
+  type SettlementTransfer,
 } from "@/services/invoices"
 
 interface TransferDialogProps {
@@ -44,6 +47,54 @@ export function TransferDialog({
   caseId,
   onSuccess,
 }: TransferDialogProps) {
+  const { data: costSharing, isLoading: sharingLoading } = useQuery({
+    queryKey: ["cost-sharing", caseId],
+    queryFn: () => getCostSharing(caseId),
+    enabled: open,
+  })
+
+  if (sharingLoading) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader><DialogTitle>Record Transfer</DialogTitle></DialogHeader>
+          <p className="text-sm text-muted-foreground py-4">Loading…</p>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  if (costSharing?.kind === "advanced") {
+    return (
+      <SettlementChecklistDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        caseId={caseId}
+        onSuccess={onSuccess}
+      />
+    )
+  }
+
+  return (
+    <SimpleTransferDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      caseId={caseId}
+      onSuccess={onSuccess}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Simple (legacy 2-party) — unchanged behavior
+// ---------------------------------------------------------------------------
+
+function SimpleTransferDialog({
+  open,
+  onOpenChange,
+  caseId,
+  onSuccess,
+}: TransferDialogProps) {
   const [direction, setDirection] = useState<"counsel_pays_us" | "we_pay_counsel">("counsel_pays_us")
   const [amount, setAmount] = useState("")
   const [creating, setCreating] = useState(false)
@@ -55,8 +106,9 @@ export function TransferDialog({
     enabled: open,
   })
 
-  const ourPct = costSharing?.our_pct ?? null
-  const partnerName = costSharing?.partner?.name ?? "Co-counsel"
+  const ourPct = costSharing?.kind === "simple" ? costSharing.our_pct : null
+  const partnerName = costSharing?.kind === "simple" ? costSharing.partner?.name ?? "Co-counsel" : "Co-counsel"
+  const partnerId = costSharing?.kind === "simple" ? costSharing.partner?.person_id ?? null : null
 
   const { data: eqData } = useQuery({
     queryKey: ["equalization", caseId, ourPct],
@@ -90,7 +142,7 @@ export function TransferDialog({
     try {
       const today = new Date().toISOString().split("T")[0]
       const isWePayThem = direction === "we_pay_counsel"
-      const counselId = eqData?.counsel_id ?? costSharing?.partner?.person_id ?? undefined
+      const counselId = eqData?.counsel_id ?? partnerId ?? undefined
 
       await createInvoice({
         case_id: caseId,
@@ -129,7 +181,6 @@ export function TransferDialog({
           </p>
         ) : (
           <div className="flex flex-col gap-4">
-            {/* Equalization hint */}
             {eqData && eqData.direction !== "even" && eqData.transfer_amount > 0 && (
               <div className="flex flex-col gap-2 border border-dashed p-3 text-sm">
                 <div className="flex justify-between">
@@ -151,7 +202,6 @@ export function TransferDialog({
               </div>
             )}
 
-            {/* Direction */}
             <div>
               <Label>Direction</Label>
               <Select value={direction} onValueChange={(v) => setDirection(v as "counsel_pays_us" | "we_pay_counsel")}>
@@ -169,7 +219,6 @@ export function TransferDialog({
               </Select>
             </div>
 
-            {/* Amount */}
             <div>
               <Label htmlFor="transfer-amount">Amount</Label>
               <div className="relative">
@@ -204,5 +253,144 @@ export function TransferDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Settlement checklist (N parties, advanced mode)
+// ---------------------------------------------------------------------------
+
+function SettlementChecklistDialog({
+  open,
+  onOpenChange,
+  caseId,
+  onSuccess,
+}: TransferDialogProps) {
+  const [selected, setSelected] = useState<Record<number, boolean>>({})
+  const [creating, setCreating] = useState(false)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["settlement", caseId],
+    queryFn: () => getSettlement(caseId),
+    enabled: open,
+  })
+
+  useEffect(() => {
+    if (data) {
+      const initial: Record<number, boolean> = {}
+      data.transfers.forEach((_, i) => { initial[i] = true })
+      setSelected(initial)
+    }
+  }, [data])
+
+  useEffect(() => {
+    if (!open) setSelected({})
+  }, [open])
+
+  async function handleCreate() {
+    if (!data) return
+    const toCreate = data.transfers.filter((_, i) => selected[i])
+    if (toCreate.length === 0) return
+
+    setCreating(true)
+    try {
+      const today = new Date().toISOString().split("T")[0]
+      // Create transfers serially so a partial failure doesn't leave us in an
+      // ambiguous state (refresh shows what was actually created).
+      for (const t of toCreate) {
+        await createInvoice({
+          case_id: caseId,
+          amount: t.amount,
+          date: today,
+          description: `Transfer from ${t.from_label ?? t.from_party} to ${t.to_label ?? t.to_party}`,
+          category: "Miscellaneous",
+          paid_by_person_id: t.from_person_id ?? undefined,
+          transfer_to_person_id: t.to_person_id ?? undefined,
+          is_transfer: true,
+        })
+      }
+      toast.success(`Recorded ${toCreate.length} transfer${toCreate.length > 1 ? "s" : ""}`)
+      onOpenChange(false)
+      onSuccess()
+    } catch {
+      toast.error("Failed to record transfers")
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const toggle = (i: number) => setSelected((s) => ({ ...s, [i]: !s[i] }))
+  const checkedCount = Object.values(selected).filter(Boolean).length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Settle Costs</DialogTitle>
+        </DialogHeader>
+
+        {isLoading || !data ? (
+          <p className="text-sm text-muted-foreground py-4">Loading…</p>
+        ) : data.transfers.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            All parties are already settled.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="text-xs text-muted-foreground">
+              Suggested transfers to bring everyone to their target share:
+            </p>
+            <div className="border divide-y">
+              {data.transfers.map((t, i) => (
+                <SettlementRow
+                  key={i}
+                  transfer={t}
+                  checked={!!selected[i]}
+                  onToggle={() => toggle(i)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {data && data.transfers.length > 0 && (
+            <Button
+              onClick={handleCreate}
+              disabled={creating || checkedCount === 0}
+            >
+              {creating ? "Recording…" : `Record ${checkedCount} transfer${checkedCount === 1 ? "" : "s"}`}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SettlementRow({
+  transfer,
+  checked,
+  onToggle,
+}: {
+  transfer: SettlementTransfer
+  checked: boolean
+  onToggle: () => void
+}) {
+  const fromLabel = transfer.from_label ?? transfer.from_party
+  const toLabel = transfer.to_label ?? transfer.to_party
+  return (
+    <label className="flex items-center gap-3 px-3 py-2.5 cursor-pointer hover:bg-accent/50 text-sm">
+      <Checkbox checked={checked} onCheckedChange={onToggle} />
+      <span className="font-medium">{fromLabel}</span>
+      <span className="text-muted-foreground">→</span>
+      <span className="font-medium">{toLabel}</span>
+      <span className="ml-auto font-semibold tabular-nums text-purple">
+        {formatCurrency(transfer.amount)}
+      </span>
+    </label>
   )
 }

--- a/frontend/src/pages/cases/costs/index.tsx
+++ b/frontend/src/pages/cases/costs/index.tsx
@@ -22,6 +22,7 @@ import {
   getAdvanceStats,
   type Invoice,
   type CostSummary,
+  type CostSharingConfig,
   type AdvanceStats,
 } from "@/services/invoices"
 import {
@@ -369,8 +370,7 @@ function CaseCostsContent() {
           {costSummary && (
             <CostSummaryBar
               costSummary={costSummary}
-              ourPct={costSharing?.our_pct ?? null}
-              counselPct={costSharing?.partner?.cost_share_pct ?? null}
+              costSharing={costSharing}
               onTransfer={() => setTransferOpen(true)}
               onSetupSplit={() => setCostSharingEditing(true)}
             />
@@ -573,18 +573,69 @@ function formatMoney(n: number) {
 
 function CostSummaryBar({
   costSummary,
-  ourPct,
-  counselPct,
+  costSharing,
   onTransfer,
   onSetupSplit,
 }: {
   costSummary: CostSummary
-  ourPct: number | null
-  counselPct: number | null
+  costSharing: CostSharingConfig | undefined
   onTransfer: () => void
   onSetupSplit: () => void
 }) {
-  const { counsel_name, total_costs, our_net, counsel_net } = costSummary
+  const { total_costs } = costSummary
+
+  // Advanced: render N parties using server-provided targets.
+  if (costSummary.kind === "advanced" && costSummary.parties && costSummary.parties.length > 0) {
+    return (
+      <div className="flex items-center gap-6 border p-3 text-sm flex-wrap">
+        <div className="flex items-center gap-1.5">
+          <span className="text-muted-foreground">Total costs:</span>
+          <span className="font-semibold tabular-nums">
+            {formatMoney(total_costs)}
+          </span>
+        </div>
+        {costSummary.parties.map((p) => {
+          const diff = p.net_paid - p.target
+          const overpaid = diff > 0.01
+          const partyPct = total_costs > 0 ? (p.target / total_costs) * 100 : 0
+          return (
+            <div key={p.party_id} className="flex items-center gap-1.5">
+              <div className="h-4 border-l" />
+              <span className="text-muted-foreground">
+                {p.label ?? p.party_id} net:
+              </span>
+              <span className="font-semibold tabular-nums">
+                {formatMoney(p.net_paid)}
+              </span>
+              {overpaid && (
+                <ImbalanceAlert
+                  who={p.label ?? p.party_id}
+                  target={p.target}
+                  actual={p.net_paid}
+                  diff={diff}
+                  pct={partyPct}
+                  totalCosts={total_costs}
+                />
+              )}
+            </div>
+          )
+        })}
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto h-7 text-xs"
+          onClick={onTransfer}
+        >
+          Settle
+        </Button>
+      </div>
+    )
+  }
+
+  // Simple (legacy 2-party) — unchanged behavior.
+  const { counsel_name, our_net, counsel_net } = costSummary
+  const ourPct = costSharing?.kind === "simple" ? costSharing.our_pct : null
+  const counselPct = costSharing?.kind === "simple" ? costSharing.partner?.cost_share_pct ?? null : null
 
   const ourTarget = ourPct != null ? total_costs * (ourPct / 100) : null
   const counselTarget = counselPct != null ? total_costs * (counselPct / 100) : null

--- a/frontend/src/services/invoices.ts
+++ b/frontend/src/services/invoices.ts
@@ -317,7 +317,17 @@ export async function calculateEqualization(
   return res.json()
 }
 
+export interface CostSummaryParty {
+  party_id: string
+  label: string | null
+  person_id: number | null
+  paid: number
+  net_paid: number
+  target: number
+}
+
 export interface CostSummary {
+  kind: "simple" | "advanced"
   total_costs: number
   our_costs: number
   counsel_costs: number
@@ -326,6 +336,9 @@ export interface CostSummary {
   net_transferred: number
   counsel_id: number | null
   counsel_name: string | null
+  // Only present in advanced mode:
+  parties?: CostSummaryParty[]
+  targets_by_party?: Record<string, number>
 }
 
 export async function getCostSummary(caseId: number): Promise<CostSummary> {
@@ -341,11 +354,66 @@ export interface CostSharingPartner {
   cost_share_pct: number | null
 }
 
-export interface CostSharingConfig {
+// Advanced config types — mirror the backend Pydantic shape.
+export interface AdvancedShare {
+  party: string
+  pct: number
+}
+
+export interface AdvancedCap {
+  party: string
+  max_cumulative: number
+  absorber?: string | null
+}
+
+export interface AdvancedPhase {
+  id: string
+  label?: string | null
+  boundary_kind: "open_start" | "date"
+  boundary_date?: string | null
+  shares: AdvancedShare[]
+  caps: AdvancedCap[]
+}
+
+export interface AdvancedParty {
+  id: string
+  label: string
+  person_id?: number | null
+  organization?: string | null
+}
+
+export interface AdvancedConfig {
+  version: number
+  parties: AdvancedParty[]
+  phases: AdvancedPhase[]
+  absorber_party: string
+}
+
+export interface AdvancedPartyWithPct {
+  party_id: string
+  label: string
+  person_id: number | null
+  organization: string | null
+  pct: number
+}
+
+// Discriminated union returned by GET /cost-sharing.
+export interface SimpleCostSharing {
+  kind: "simple"
   co_counsel: CostSharingPartner[]
   partner: CostSharingPartner | null
   our_pct: number | null
 }
+
+export interface AdvancedCostSharing {
+  kind: "advanced"
+  co_counsel: CostSharingPartner[]
+  config: AdvancedConfig
+  parties_with_pct: AdvancedPartyWithPct[]
+  absorber_party: string
+}
+
+export type CostSharingConfig = SimpleCostSharing | AdvancedCostSharing
 
 export async function getCostSharing(caseId: number): Promise<CostSharingConfig> {
   const res = await apiFetch(`/api/v1/cases/${caseId}/cost-sharing`)
@@ -377,6 +445,70 @@ export async function removeCostSharing(
     const data = await res.json().catch(() => null)
     throw new Error(data?.error?.message ?? "Failed to remove cost sharing")
   }
+  return res.json()
+}
+
+export async function setCostSharingConfig(
+  caseId: number,
+  config: AdvancedConfig
+): Promise<CostSharingConfig> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/cost-sharing-config`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error?.message ?? "Failed to update cost sharing config")
+  }
+  return res.json()
+}
+
+export async function removeCostSharingConfig(
+  caseId: number
+): Promise<CostSharingConfig> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/cost-sharing-config`, {
+    method: "DELETE",
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error?.message ?? "Failed to reset cost sharing")
+  }
+  return res.json()
+}
+
+export interface SettlementTransfer {
+  from_party: string
+  to_party: string
+  amount: number
+  from_label: string | null
+  to_label: string | null
+  from_person_id: number | null
+  to_person_id: number | null
+}
+
+export interface SettlementPartyMeta {
+  party_id: string
+  label: string | null
+  person_id: number | null
+  organization: string | null
+}
+
+export interface Settlement {
+  kind: "simple" | "advanced"
+  config: AdvancedConfig
+  parties: string[]
+  parties_meta: SettlementPartyMeta[]
+  targets: Record<string, number>
+  paid: Record<string, number>
+  net_paid: Record<string, number>
+  deltas: Record<string, number>
+  transfers: SettlementTransfer[]
+}
+
+export async function getSettlement(caseId: number): Promise<Settlement> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/settlement`)
+  if (!res.ok) throw new Error("Failed to fetch settlement")
   return res.json()
 }
 

--- a/models.py
+++ b/models.py
@@ -299,6 +299,11 @@ class Case(Base):
 
     notes: Mapped[Optional[str]] = mapped_column(Text)
 
+    # When NULL, simple cost-sharing applies via PersonRole.cost_share_pct.
+    # When populated, the JSONB document is the source of truth and supports
+    # N parties, phases, and caps. See db/cost_sharing.py.
+    cost_sharing_config: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+
     # Relationships
     comments: Mapped[list[CaseComment]] = relationship(back_populates="case", passive_deletes=True)
     events: Mapped[list[Event]] = relationship(back_populates="case", passive_deletes=True)
@@ -1128,6 +1133,7 @@ class Invoice(Base):
         Index("idx_invoices_due_date", "due_date"),
         Index("idx_invoices_date", "date"),
         Index("idx_invoices_type", "type"),
+        Index("idx_invoices_phase_id", "phase_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -1157,6 +1163,9 @@ class Invoice(Base):
     is_transfer: Mapped[bool] = mapped_column(
         server_default=text("false")
     )
+    # Phase membership for advanced cost-sharing. NULL when the case is in
+    # simple mode, or when a phased config has not yet been bucketed.
+    phase_id: Mapped[Optional[str]] = mapped_column(Text)
     created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime(timezone=True), server_default=text("CURRENT_TIMESTAMP")
     )

--- a/routes/invoices.py
+++ b/routes/invoices.py
@@ -12,7 +12,12 @@ from pydantic import ValidationError
 import auth
 import db
 from config import settings
-from schemas import CreateInvoiceInput, UpdateInvoiceInput, MarkInvoicePaidInput
+from schemas import (
+    CreateInvoiceInput,
+    UpdateInvoiceInput,
+    MarkInvoicePaidInput,
+    CostSharingConfigInput,
+)
 from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
 
 logger = logging.getLogger(__name__)
@@ -178,6 +183,45 @@ def register_invoice_routes(mcp):
         case_id = int(request.path_params["case_id"])
         try:
             result = await asyncio.to_thread(db.remove_cost_sharing, case_id)
+            return JSONResponse(result)
+        except ValueError as e:
+            return api_error(str(e), "VALIDATION_ERROR", 400)
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/cost-sharing-config", methods=["PUT"])
+    async def api_set_cost_sharing_config(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        try:
+            data = CostSharingConfigInput(**(await request.json()))
+        except ValidationError as e:
+            return pydantic_error(e)
+        try:
+            result = await asyncio.to_thread(
+                db.set_cost_sharing_config, case_id, data.model_dump()
+            )
+            return JSONResponse(result)
+        except ValueError as e:
+            return api_error(str(e), "VALIDATION_ERROR", 400)
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/cost-sharing-config", methods=["DELETE"])
+    async def api_remove_cost_sharing_config(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        try:
+            result = await asyncio.to_thread(db.remove_cost_sharing_config, case_id)
+            return JSONResponse(result)
+        except ValueError as e:
+            return api_error(str(e), "VALIDATION_ERROR", 400)
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/settlement", methods=["GET"])
+    async def api_get_settlement(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        try:
+            result = await asyncio.to_thread(db.get_settlement, case_id)
             return JSONResponse(result)
         except ValueError as e:
             return api_error(str(e), "VALIDATION_ERROR", 400)

--- a/schemas/inputs.py
+++ b/schemas/inputs.py
@@ -5,7 +5,7 @@ Used by both MCP tools and REST routes.
 """
 
 from typing import Literal, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .common import CaseStatus, TaskStatus, Urgency, IntakeStatus, ResolutionType
 
@@ -265,6 +265,95 @@ class UpdateInvoiceInput(BaseModel):
 class MarkInvoicePaidInput(BaseModel):
     check_number: Optional[str] = None
     paid_date: Optional[str] = None
+
+
+# =============================================================================
+# Route Input Models — Cost-Sharing Config (advanced)
+# =============================================================================
+
+class CostShareInput(BaseModel):
+    party: str
+    pct: float = Field(ge=0, le=100)
+
+
+class CostCapInput(BaseModel):
+    party: str
+    max_cumulative: float = Field(ge=0)
+    absorber: Optional[str] = None  # party_id; defaults to config.absorber_party
+
+
+class CostPhaseInput(BaseModel):
+    id: str
+    label: Optional[str] = None
+    boundary_kind: Literal["open_start", "date"]
+    boundary_date: Optional[str] = None  # YYYY-MM-DD
+    shares: list[CostShareInput]
+    caps: list[CostCapInput] = []
+
+    @model_validator(mode="after")
+    def _check_shares(self):
+        total = sum(s.pct for s in self.shares)
+        if abs(total - 100) > 0.01:
+            raise ValueError(
+                f"Phase '{self.id}' shares must sum to 100, got {total:.2f}"
+            )
+        if self.boundary_kind == "date" and not self.boundary_date:
+            raise ValueError(f"Phase '{self.id}' has boundary_kind=date but no boundary_date")
+        return self
+
+
+class CostPartyInput(BaseModel):
+    id: str
+    label: str
+    person_id: Optional[int] = None  # None for our firm
+    organization: Optional[str] = None
+
+
+class CostSharingConfigInput(BaseModel):
+    version: int = 1
+    parties: list[CostPartyInput]
+    phases: list[CostPhaseInput]
+    absorber_party: str = "ours"
+
+    @model_validator(mode="after")
+    def _validate_config(self):
+        party_ids = [p.id for p in self.parties]
+        if len(party_ids) != len(set(party_ids)):
+            raise ValueError("Party IDs must be unique")
+        if "ours" not in party_ids:
+            raise ValueError("Config must include a party with id='ours'")
+        if self.absorber_party not in party_ids:
+            raise ValueError(
+                f"absorber_party '{self.absorber_party}' is not a known party"
+            )
+        if not self.phases:
+            raise ValueError("Config must have at least one phase")
+        if self.phases[0].boundary_kind != "open_start":
+            raise ValueError("First phase must have boundary_kind='open_start'")
+        for phase in self.phases[1:]:
+            if phase.boundary_kind != "date":
+                raise ValueError("Non-first phases must have boundary_kind='date'")
+        # Check phase ordinals are monotonic by date.
+        dates = [p.boundary_date for p in self.phases[1:] if p.boundary_date]
+        if dates != sorted(dates):
+            raise ValueError("Phase boundary_dates must be in chronological order")
+
+        for phase in self.phases:
+            for share in phase.shares:
+                if share.party not in party_ids:
+                    raise ValueError(
+                        f"Phase '{phase.id}' references unknown party '{share.party}'"
+                    )
+            for cap in phase.caps:
+                if cap.party not in party_ids:
+                    raise ValueError(
+                        f"Phase '{phase.id}' cap references unknown party '{cap.party}'"
+                    )
+                if cap.absorber and cap.absorber not in party_ids:
+                    raise ValueError(
+                        f"Phase '{phase.id}' cap absorber '{cap.absorber}' is not a known party"
+                    )
+        return self
 
 
 # =============================================================================

--- a/services/cost_report_generator.py
+++ b/services/cost_report_generator.py
@@ -44,9 +44,10 @@ def _build_html(
     total_count = len(real_invoices)
     subtitle = f'{total_count} invoice{"s" if total_count != 1 else ""}'
 
+    is_advanced = cost_sharing.get('kind') == 'advanced'
     partner = cost_sharing.get('partner')
     our_pct = cost_sharing.get('our_pct')
-    has_sharing = partner is not None and our_pct is not None
+    has_sharing = is_advanced or (partner is not None and our_pct is not None)
 
     summary_html = _render_summary(cost_summary, cost_sharing)
 
@@ -154,6 +155,38 @@ def _build_html(
 
 def _render_summary(cost_summary: dict, cost_sharing: dict) -> str:
     total = cost_summary.get('total_costs', 0)
+
+    # Advanced (N parties): render per-party rows from cost_summary['parties'].
+    if cost_summary.get('kind') == 'advanced' and cost_summary.get('parties'):
+        parties = cost_summary['parties']
+        items = [f"""
+        <div class="summary-item">
+          <span class="summary-label">Total Costs</span>
+          <span class="summary-value">{_fmt_money(total)}</span>
+        </div>"""]
+        owes_lines = []
+        for p in parties:
+            label = p.get('label') or p.get('party_id', '')
+            net_paid = float(p.get('net_paid', 0))
+            target = float(p.get('target', 0))
+            pct = (target / total * 100) if total > 0 else 0
+            items.append(f"""<div class="summary-sep"></div>
+        <div class="summary-item">
+          <span class="summary-label">{escape(label)} ({pct:.0f}%)</span>
+          <span class="summary-value">{_fmt_money(net_paid)}</span>
+        </div>""")
+            diff = net_paid - target
+            if diff > 0.01:
+                owes_lines.append(
+                    f'<div class="owes-line owes-danger">{escape(label)} is owed {_fmt_money(diff)}</div>'
+                )
+        return f"""
+    <div class="summary-bar">
+      {''.join(items)}
+    </div>
+    {''.join(owes_lines)}"""
+
+    # Simple (legacy 2-party).
     partner = cost_sharing.get('partner')
     our_pct = cost_sharing.get('our_pct')
     has_sharing = partner is not None and our_pct is not None
@@ -171,14 +204,11 @@ def _render_summary(cost_summary: dict, cost_sharing: dict) -> str:
     counsel_pct = partner.get('cost_share_pct', 0)
     our_net = cost_summary.get('our_net', 0)
     counsel_net = cost_summary.get('counsel_net', 0)
-    our_costs = cost_summary.get('our_costs', 0)
-    counsel_costs = cost_summary.get('counsel_costs', 0)
     net_transferred = cost_summary.get('net_transferred', 0)
 
     our_target = total * (our_pct / 100.0)
     counsel_target = total * (counsel_pct / 100.0)
     our_diff = our_net - our_target
-    counsel_diff = counsel_net - counsel_target
 
     owes_html = ''
     if abs(our_diff) > 0.01:


### PR DESCRIPTION
## Summary

Extends the cost-sharing system from a simple 2-party model (firm + one partner) to support flexible N-party configurations with per-phase allocation rules, caps, and automatic settlement computation. Introduces a pure-function cost allocator (`db/cost_sharing.py`) and UI for managing advanced configurations alongside the legacy simple mode.

## Key Changes

### Backend
- **New module `db/cost_sharing.py`**: Pure-function allocator that computes target contributions per party based on configurable phases, shares, and cumulative caps. Includes settlement minimizer using greedy algorithm.
- **Database schema**: Added `cost_sharing_config` (JSONB) to `Case` and `phase_id` (Text) to `Invoice` for phase bucketing.
- **Cost sharing endpoints**: 
  - `PUT /api/v1/cases/{case_id}/cost-sharing-config` — set advanced config
  - `DELETE /api/v1/cases/{case_id}/cost-sharing-config` — reset to simple mode
  - `GET /api/v1/cases/{case_id}/settlement` — compute settlement transfers
- **Invoice phase bucketing**: Invoices automatically assigned to phases based on date when config is present; phase_id updated on invoice date changes.
- **Cost summary enrichment**: `get_cost_summary()` now returns discriminated `{kind: "simple" | "advanced", ...}` with per-party breakdown and targets in advanced mode.
- **Pydantic schemas** (`schemas/inputs.py`): `CostSharingConfigInput`, `CostPhaseInput`, `CostShareInput`, `CostCapInput` with validation (shares sum to 100, phase boundaries ordered, etc.).

### Frontend
- **Advanced editor UI** (`cost-sharing-bar.tsx`): New `AdvancedEditor` component for managing N parties with per-party percentage rows. Supports adding/removing parties and editing shares. Seeded from simple form when upgrading.
- **Discriminated cost-sharing state**: `getCostSharing()` returns `SimpleCostSharing | AdvancedCostSharing` union; UI branches on `kind` field.
- **Settlement checklist** (`equalization-dialog.tsx`): New `SettlementChecklistDialog` for advanced mode showing computed transfers with checkboxes to selectively record them.
- **Cost summary display**: `CostSummaryBar` renders N-party breakdown with targets in advanced mode; simple 2-party view in legacy mode.
- **TypeScript types**: New interfaces for `AdvancedConfig`, `AdvancedPhase`, `AdvancedParty`, `AdvancedShare`, `AdvancedCap`, `SettlementTransfer`.

### Services & Utilities
- **Cost report generator**: Updated to detect advanced mode and render per-party summary rows.
- **Alembic migration**: `274c0f660dad` adds `cost_sharing_config` column and `phase_id` column.

## Implementation Details

- **Party IDs**: Firm is `"ours"`, person-backed parties use `"p:<person_id>"` convention.
- **Phases**: Ordered by position; first phase always `boundary_kind="open_start"`, subsequent phases use `boundary_kind="date"` with boundary dates. Invoices bucketed to latest phase whose boundary_date ≤ invoice.date.
- **Caps**: Per-party cumulative caps with optional absorber party (defaults to config absorber). Applied iteratively until no party exceeds cap.
- **Settlement**: Greedy algorithm matches creditors (overpaid) to debtors (underpaid) to minimize transaction count.
- **Backward compatibility**: Simple mode (no config) continues to work unchanged; UI auto-detects and branches on `kind` field.
- **State initialization**: When entering edit mode, state is populated from either simple partner data or advanced config parties; switching modes seeds the target editor with current form values.

https://claude.ai/code/session_01JSnajFUfpb5bsZBGwS7WQU