### PR TITLE
feat: per-case section toggles to keep the default view minimal

### DIFF
--- a/alembic/versions/a1f4e2c83b91_add_feature_toggles_to_cases.py
+++ b/alembic/versions/a1f4e2c83b91_add_feature_toggles_to_cases.py
@@ -1,0 +1,30 @@
+"""add feature_toggles column to cases
+
+Revision ID: a1f4e2c83b91
+Revises: e845739db79f
+Create Date: 2026-05-15 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1f4e2c83b91'
+down_revision: Union[str, Sequence[str], None] = 'e845739db79f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'cases',
+        sa.Column('feature_toggles', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('cases', 'feature_toggles')

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -70,6 +70,17 @@ from .cases import (
     get_cases_for_user,
 )
 
+from .feature_gates import (
+    FeatureDisabled,
+    FEATURE_TASKS,
+    FEATURE_EVENTS,
+    FEATURE_FINANCIALS,
+    FEATURE_COSTS,
+    is_feature_enabled,
+    require_feature_for_case,
+    feature_enabled_filter,
+)
+
 # Role operations (replaces person_types)
 from .roles import (
     get_roles,

--- a/db/cases.py
+++ b/db/cases.py
@@ -217,6 +217,7 @@ def get_case_by_id(case_id: int) -> Optional[dict]:
             "created_at": _sv(case.created_at),
             "notes": case.notes,
             "updated_at": _sv(case.updated_at),
+            "feature_toggles": case.feature_toggles,
         }
 
         # Expand attorney_ids to user objects
@@ -428,12 +429,14 @@ def update_case(case_id: int, **kwargs) -> Optional[dict]:
         "trial_date", "proposed_trial_dates",
         "trial_likelihood", "trial_likelihood_note",
         "trial_estimated_days", "claim_deadline", "complaint_deadline",
+        "feature_toggles",
     ]
 
     nullable_fields = {
         "date_of_injury", "trial_date", "claim_deadline", "complaint_deadline",
         "proposed_trial_dates", "trial_likelihood", "trial_likelihood_note",
         "trial_estimated_days", "notes", "result", "case_summary",
+        "feature_toggles",
     }
 
     with SessionLocal() as session:

--- a/db/cases.py
+++ b/db/cases.py
@@ -279,27 +279,34 @@ def get_case_by_id(case_id: int) -> Optional[dict]:
             persons.append(person)
         result["persons"] = persons
 
-        # Events
-        evt_stmt = (
-            select(Event.id, Event.date, Event.time, Event.location,
-                   Event.description, Event.document_link,
-                   Event.calculation_note, Event.starred)
-            .where(Event.case_id == case_id)
-            .order_by(Event.date)
-        )
-        result["events"] = [_row_to_dict(r) for r in session.execute(evt_stmt)]
+        # Events — only included when the feature is enabled for this case
+        toggles = case.feature_toggles or {}
+        if toggles.get("events"):
+            evt_stmt = (
+                select(Event.id, Event.date, Event.time, Event.location,
+                       Event.description, Event.document_link,
+                       Event.calculation_note, Event.starred)
+                .where(Event.case_id == case_id)
+                .order_by(Event.date)
+            )
+            result["events"] = [_row_to_dict(r) for r in session.execute(evt_stmt)]
+        else:
+            result["events"] = []
 
-        # Tasks with event description
-        task_stmt = (
-            select(Task.id, Task.due_date, Task.completion_date, Task.description,
-                   Task.status, Task.urgency, Task.event_id, Task.sort_order,
-                   Task.created_at, Task.updated_at, Task.assignee_id,
-                   Event.description.label("event_description"))
-            .outerjoin(Event, Event.id == Task.event_id)
-            .where(Task.case_id == case_id)
-            .order_by(Task.sort_order.asc())
-        )
-        result["tasks"] = [_row_to_dict(r) for r in session.execute(task_stmt)]
+        # Tasks — only included when the feature is enabled for this case
+        if toggles.get("tasks"):
+            task_stmt = (
+                select(Task.id, Task.due_date, Task.completion_date, Task.description,
+                       Task.status, Task.urgency, Task.event_id, Task.sort_order,
+                       Task.created_at, Task.updated_at, Task.assignee_id,
+                       Event.description.label("event_description"))
+                .outerjoin(Event, Event.id == Task.event_id)
+                .where(Task.case_id == case_id)
+                .order_by(Task.sort_order.asc())
+            )
+            result["tasks"] = [_row_to_dict(r) for r in session.execute(task_stmt)]
+        else:
+            result["tasks"] = []
 
         # Proceedings with jurisdiction
         proc_stmt = (

--- a/db/events.py
+++ b/db/events.py
@@ -12,6 +12,10 @@ from sqlalchemy.orm import joinedload
 from .session import SessionLocal
 from .connection import _NOT_PROVIDED
 from .validation import validate_date_format, validate_time_format
+from .feature_gates import (
+    FEATURE_EVENTS, FEATURE_TASKS, feature_enabled_filter,
+    require_feature_for_case, is_feature_enabled,
+)
 from models import Event, Case, Task, User
 from schemas import EventOut
 
@@ -55,6 +59,7 @@ def add_event(case_id: int = None, date: str = "", description: str = "",
         validate_date_format(end_date, "end_date")
 
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_EVENTS)
         event = Event(
             case_id=case_id,
             date=date,
@@ -93,6 +98,9 @@ def get_upcoming_events(limit: int = None, offset: int = None, include_past: boo
     # Build base query
     stmt = select(Event, Case, task_count_sq.label("task_count")).outerjoin(Case, Event.case_id == Case.id)
 
+    feature_clause = feature_enabled_filter(FEATURE_EVENTS, Event.case_id)
+    stmt = stmt.where(feature_clause)
+
     # Date conditions
     if include_past:
         stmt = stmt.where(Event.date >= today - past_days, Event.date < today)
@@ -121,6 +129,7 @@ def get_upcoming_events(limit: int = None, offset: int = None, include_past: boo
     with SessionLocal() as session:
         # Count query — same filters
         count_base = select(Event.id).outerjoin(Case, Event.case_id == Case.id)
+        count_base = count_base.where(feature_clause)
         if include_past:
             count_base = count_base.where(Event.date >= today - past_days, Event.date < today)
         else:
@@ -160,9 +169,11 @@ def get_events(case_id: int = None) -> dict:
         .scalar_subquery()
     )
 
+    feature_clause = feature_enabled_filter(FEATURE_EVENTS, Event.case_id)
     stmt = (
         select(Event, Case, task_count_sq.label("task_count"))
         .outerjoin(Case, Event.case_id == Case.id)
+        .where(feature_clause)
         .order_by(Event.date)
     )
 
@@ -170,7 +181,7 @@ def get_events(case_id: int = None) -> dict:
         stmt = stmt.where(Event.case_id == case_id)
 
     with SessionLocal() as session:
-        count_base = select(Event.id)
+        count_base = select(Event.id).where(feature_clause)
         if case_id:
             count_base = count_base.where(Event.case_id == case_id)
         total = session.scalar(select(func.count()).select_from(count_base.subquery()))
@@ -193,6 +204,7 @@ def update_event(event_id: int, starred: bool = None) -> Optional[dict]:
         event = session.get(Event, event_id)
         if not event:
             return None
+        require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         event.starred = starred
         session.flush()
@@ -216,6 +228,7 @@ def update_event_full(event_id: int, date: str = _NOT_PROVIDED, description: str
         event = session.get(Event, event_id)
         if not event:
             return None
+        require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         if date is not _NOT_PROVIDED:
             if date is not None:
@@ -261,9 +274,13 @@ def update_event_full(event_id: int, date: str = _NOT_PROVIDED, description: str
 
 
 def get_tasks_for_event(event_id: int) -> List[dict]:
-    """Get tasks linked to an event."""
+    """Get tasks linked to an event (only on cases where tasks are enabled)."""
     with SessionLocal() as session:
-        stmt = select(Task).where(Task.event_id == event_id)
+        stmt = (
+            select(Task)
+            .where(Task.event_id == event_id)
+            .where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
+        )
         tasks = session.scalars(stmt).all()
         return [{"id": t.id, "description": t.description} for t in tasks]
 
@@ -274,6 +291,7 @@ def delete_event(event_id: int) -> bool:
         event = session.get(Event, event_id)
         if not event:
             return False
+        require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         # Delete linked tasks first
         session.execute(
@@ -296,6 +314,7 @@ def search_events(query: str = None, case_id: int = None,
     stmt = (
         select(Event, Case)
         .outerjoin(Case, Event.case_id == Case.id)
+        .where(feature_enabled_filter(FEATURE_EVENTS, Event.case_id))
         .order_by(Event.date)
         .limit(limit)
     )
@@ -347,6 +366,7 @@ def get_calendar(days: int = 30, include_tasks: bool = True,
                 select(Event, Case)
                 .outerjoin(Case, Event.case_id == Case.id)
                 .where(Event.date >= today, Event.date <= today + days)
+                .where(feature_enabled_filter(FEATURE_EVENTS, Event.case_id))
                 .order_by(Event.date, Event.time.asc().nulls_last())
             )
             for event, case in session.execute(stmt).all():
@@ -373,6 +393,7 @@ def get_calendar(days: int = 30, include_tasks: bool = True,
                     Task.due_date <= today + days,
                     Task.status != "Done",
                 )
+                .where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
                 .order_by(Task.due_date)
             )
             for task, case in session.execute(stmt).all():
@@ -436,6 +457,7 @@ def add_event_attendee(event_id: int, user_id: int) -> dict:
         event = session.get(Event, event_id)
         if not event:
             return {"success": False, "error": "Event not found"}
+        require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         current = list(event.attendee_ids or [])
         if user_id not in current:
@@ -455,6 +477,7 @@ def remove_event_attendee(event_id: int, user_id: int) -> dict:
         event = session.get(Event, event_id)
         if not event:
             return {"success": False, "error": "Event not found"}
+        require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         current = list(event.attendee_ids or [])
         if user_id in current:
@@ -487,6 +510,8 @@ def get_event_by_id(event_id: int) -> Optional[dict]:
             return None
 
         event, case, tc = row
+        if event.case_id is not None and not is_feature_enabled(session, event.case_id, FEATURE_EVENTS):
+            return None
         result = _event_with_case_dict(event, case, tc)
         result["attendee_ids"] = event.attendee_ids or []
         result["created_at"] = _serialize_value(event.created_at)

--- a/db/feature_gates.py
+++ b/db/feature_gates.py
@@ -1,0 +1,96 @@
+"""
+Per-case feature gates.
+
+When `Case.feature_toggles[<feature>]` is not exactly `true`, that feature
+is disabled for the case:
+
+- Cross-case list/search queries filter out rows belonging to the case.
+- Single-item reads return None (route layer turns this into 404).
+- Create/update/delete operations raise FeatureDisabled.
+
+Existing data is preserved when a feature is turned off — toggling back on
+makes it reappear unchanged.
+
+Feature keys (must match the frontend `CaseFeatureKey` union):
+
+    tasks       -> Task rows
+    events      -> Event rows
+    financials  -> CaseFinancial + CounselFee rows
+    costs       -> Invoice + Lien rows (the entire case-costs page)
+
+Rows with a NULL case_id (e.g., unassigned tasks) are never filtered out
+because they don't belong to any case.
+"""
+
+from typing import Optional
+
+from sqlalchemy import or_, select as sa_select
+from sqlalchemy.orm import Session
+
+from models import Case
+
+
+FEATURE_TASKS = "tasks"
+FEATURE_EVENTS = "events"
+FEATURE_FINANCIALS = "financials"
+FEATURE_COSTS = "costs"
+
+ALL_FEATURES = (FEATURE_TASKS, FEATURE_EVENTS, FEATURE_FINANCIALS, FEATURE_COSTS)
+
+
+class FeatureDisabled(Exception):
+    """Raised when an operation requires a case feature that is disabled."""
+
+    _LABELS = {
+        FEATURE_TASKS: "Tasks",
+        FEATURE_EVENTS: "Events",
+        FEATURE_FINANCIALS: "Financials",
+        FEATURE_COSTS: "Costs",
+    }
+
+    def __init__(self, case_id: int, feature: str):
+        self.case_id = case_id
+        self.feature = feature
+        label = self._LABELS.get(feature, feature)
+        super().__init__(
+            f"{label} are disabled for case {case_id}. "
+            f"Enable from the gear menu on the case page."
+        )
+
+
+def is_feature_enabled(session: Session, case_id: int, feature: str) -> bool:
+    """True if the given case has the feature toggle set to True."""
+    case = session.get(Case, case_id)
+    if case is None:
+        return False
+    return bool((case.feature_toggles or {}).get(feature))
+
+
+def require_feature_for_case(
+    session: Session, case_id: Optional[int], feature: str
+) -> None:
+    """Raise FeatureDisabled if the case has the feature off.
+
+    case_id=None is allowed (unassigned rows aren't tied to any case).
+    """
+    if case_id is None:
+        return
+    if not is_feature_enabled(session, case_id, feature):
+        raise FeatureDisabled(case_id, feature)
+
+
+def feature_enabled_filter(feature: str, case_id_col):
+    """SQLAlchemy WHERE clause limiting to rows whose case has feature enabled.
+
+    Rows with case_id IS NULL are always included.
+
+        stmt = select(Task).where(feature_enabled_filter("tasks", Task.case_id))
+    """
+    return or_(
+        case_id_col.is_(None),
+        case_id_col.in_(
+            sa_select(Case.id).where(
+                Case.feature_toggles[feature].astext == "true"
+            )
+        ),
+    )

--- a/db/financials.py
+++ b/db/financials.py
@@ -10,6 +10,10 @@ from uuid import UUID
 from sqlalchemy import select, func, literal_column
 
 from .session import SessionLocal
+from .feature_gates import (
+    FEATURE_FINANCIALS, feature_enabled_filter, require_feature_for_case,
+    is_feature_enabled,
+)
 from models import Case, CaseFinancial, CaseCounselFee, User
 
 
@@ -41,7 +45,7 @@ def get_all_financials(
 ) -> dict:
     """Get all case financials joined with case info."""
     with SessionLocal() as session:
-        filters = []
+        filters = [feature_enabled_filter(FEATURE_FINANCIALS, CaseFinancial.case_id)]
         if resolution_type:
             filters.append(CaseFinancial.resolution_type == resolution_type)
         if is_finalized is not None:
@@ -122,6 +126,8 @@ def get_financial_by_id(financial_id: int) -> Optional[dict]:
         fin = session.get(CaseFinancial, financial_id)
         if not fin:
             return None
+        if not is_feature_enabled(session, fin.case_id, FEATURE_FINANCIALS):
+            return None
 
         result = {
             "id": fin.id,
@@ -171,6 +177,7 @@ def get_financial_by_id(financial_id: int) -> Optional[dict]:
 def create_financial(case_id: int, **kwargs) -> dict:
     """Create a financial record for a case. Auto-creates an 'our firm' counsel fee."""
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_FINANCIALS)
         fin = CaseFinancial(case_id=case_id, **kwargs)
         session.add(fin)
         session.flush()
@@ -198,6 +205,7 @@ def update_financial(financial_id: int, **kwargs) -> Optional[dict]:
         fin = session.get(CaseFinancial, financial_id)
         if not fin:
             return None
+        require_feature_for_case(session, fin.case_id, FEATURE_FINANCIALS)
         changed = False
         for field, value in kwargs.items():
             if field not in allowed:
@@ -216,6 +224,7 @@ def delete_financial(financial_id: int) -> bool:
         fin = session.get(CaseFinancial, financial_id)
         if not fin:
             return False
+        require_feature_for_case(session, fin.case_id, FEATURE_FINANCIALS)
         session.delete(fin)
         session.commit()
         return True
@@ -224,6 +233,8 @@ def delete_financial(financial_id: int) -> bool:
 def get_financial_by_case(case_id: int) -> Optional[dict]:
     """Get the financial record for a case (one-to-one)."""
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_FINANCIALS):
+            return None
         fin_id = session.scalar(
             select(CaseFinancial.id).where(CaseFinancial.case_id == case_id)
         )
@@ -236,9 +247,21 @@ def get_financial_by_case(case_id: int) -> Optional[dict]:
 # Counsel Fee CRUD
 # =============================================================================
 
+def _counsel_fee_case_id(session, fee_id: int) -> Optional[int]:
+    """Look up the case_id for a counsel fee (via its parent financial)."""
+    return session.scalar(
+        select(CaseFinancial.case_id)
+        .join(CaseCounselFee, CaseCounselFee.financial_id == CaseFinancial.id)
+        .where(CaseCounselFee.id == fee_id)
+    )
+
+
 def create_counsel_fee(financial_id: int, **kwargs) -> dict:
     """Create a counsel fee record."""
     with SessionLocal() as session:
+        fin = session.get(CaseFinancial, financial_id)
+        if fin is not None:
+            require_feature_for_case(session, fin.case_id, FEATURE_FINANCIALS)
         fee = CaseCounselFee(financial_id=financial_id, **kwargs)
         session.add(fee)
         session.flush()
@@ -257,6 +280,8 @@ def update_counsel_fee(fee_id: int, **kwargs) -> Optional[dict]:
         fee = session.get(CaseCounselFee, fee_id)
         if not fee:
             return None
+        case_id = _counsel_fee_case_id(session, fee_id)
+        require_feature_for_case(session, case_id, FEATURE_FINANCIALS)
         for field, value in kwargs.items():
             if field not in allowed:
                 continue
@@ -272,6 +297,8 @@ def delete_counsel_fee(fee_id: int) -> Optional[dict]:
         fee = session.get(CaseCounselFee, fee_id)
         if not fee:
             return None
+        case_id = _counsel_fee_case_id(session, fee_id)
+        require_feature_for_case(session, case_id, FEATURE_FINANCIALS)
         fid = fee.financial_id
         session.delete(fee)
         session.commit()
@@ -284,6 +311,7 @@ def get_resolution_type_counts(attorney_ids: Optional[List[int]] = None) -> dict
         stmt = (
             select(CaseFinancial.resolution_type, func.count(CaseFinancial.id))
             .join(Case, Case.id == CaseFinancial.case_id)
+            .where(feature_enabled_filter(FEATURE_FINANCIALS, CaseFinancial.case_id))
             .group_by(CaseFinancial.resolution_type)
         )
         if attorney_ids:

--- a/db/invoices.py
+++ b/db/invoices.py
@@ -9,6 +9,10 @@ from sqlalchemy import select, func, case as sa_case
 
 from .session import SessionLocal
 from . import cost_sharing as cs
+from .feature_gates import (
+    FEATURE_COSTS, feature_enabled_filter, require_feature_for_case,
+    is_feature_enabled,
+)
 from models import Invoice, Case, CaseComment, Person, Payee, PersonRole, Role
 
 
@@ -119,6 +123,7 @@ def list_invoices(
         .outerjoin(advanced_to, Invoice.advanced_to_person_id == advanced_to.c.id)
     )
 
+    stmt = stmt.where(feature_enabled_filter(FEATURE_COSTS, Invoice.case_id))
     if case_id:
         stmt = stmt.where(Invoice.case_id == case_id)
     if status:
@@ -147,7 +152,9 @@ def list_invoices(
     else:
         stmt = stmt.order_by(sort_col.asc().nullslast(), Invoice.created_at.asc())
 
-    count_sub = select(Invoice.id)
+    count_sub = select(Invoice.id).where(
+        feature_enabled_filter(FEATURE_COSTS, Invoice.case_id)
+    )
     if case_id:
         count_sub = count_sub.where(Invoice.case_id == case_id)
     if status:
@@ -191,6 +198,8 @@ def get_invoice(invoice_id: int) -> Optional[dict]:
         if not row:
             return None
         inv, case_name, pbn, payee_name, payee_addr, ttn, atn = row
+        if not is_feature_enabled(session, inv.case_id, FEATURE_COSTS):
+            return None
         return _invoice_to_dict(inv, case_name, pbn, payee_name, payee_addr, ttn, atn)
 
 
@@ -217,6 +226,7 @@ def create_invoice(
     is_transfer: bool = False,
 ) -> dict:
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_COSTS)
         if type == "advance":
             category = "Advance"
         inv = Invoice(
@@ -291,6 +301,7 @@ def update_invoice(invoice_id: int, **fields) -> Optional[dict]:
         inv = session.get(Invoice, invoice_id)
         if not inv:
             return None
+        require_feature_for_case(session, inv.case_id, FEATURE_COSTS)
 
         for key, value in fields.items():
             if hasattr(inv, key):
@@ -336,6 +347,7 @@ def mark_invoice_paid(
         inv = session.get(Invoice, invoice_id)
         if not inv:
             return None
+        require_feature_for_case(session, inv.case_id, FEATURE_COSTS)
 
         inv.status = "paid"
         inv.check_number = check_number
@@ -387,6 +399,7 @@ def mark_invoice_unpaid(invoice_id: int) -> Optional[dict]:
         inv = session.get(Invoice, invoice_id)
         if not inv:
             return None
+        require_feature_for_case(session, inv.case_id, FEATURE_COSTS)
 
         inv.status = "unpaid"
         inv.check_number = None
@@ -427,6 +440,7 @@ def delete_invoice(invoice_id: int) -> bool:
         inv = session.get(Invoice, invoice_id)
         if not inv:
             return False
+        require_feature_for_case(session, inv.case_id, FEATURE_COSTS)
 
         if inv.file_path and os.path.isfile(inv.file_path):
             try:
@@ -448,6 +462,13 @@ def calculate_equalization(case_id: int, our_share_pct: float) -> dict:
     """
     effective_amount = func.coalesce(Invoice.case_amount, Invoice.amount)
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {
+                "grand_total": 0, "our_total_paid": 0, "counsel_total_paid": 0,
+                "our_share_pct": our_share_pct, "our_target": 0, "counsel_target": 0,
+                "transfer_amount": 0, "already_transferred": 0, "direction": "even",
+                "counsel_id": None, "counsel_name": None,
+            }
         rows = session.execute(
             select(
                 Invoice.paid_by_person_id,
@@ -535,12 +556,15 @@ def calculate_equalization(case_id: int, our_share_pct: float) -> dict:
 def get_invoice_stats(case_id: int = None, type: str = None) -> dict:
     effective_amount = func.coalesce(Invoice.case_amount, Invoice.amount)
     with SessionLocal() as session:
+        if case_id is not None and not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {"unpaid_count": 0, "unpaid_total": "0", "paid_count": 0, "paid_total": "0"}
         base = select(
             func.count().filter(Invoice.status == "unpaid").label("unpaid_count"),
             func.coalesce(func.sum(sa_case((Invoice.status == "unpaid", effective_amount), else_=0)), 0).label("unpaid_total"),
             func.count().filter(Invoice.status == "paid").label("paid_count"),
             func.coalesce(func.sum(sa_case((Invoice.status == "paid", effective_amount), else_=0)), 0).label("paid_total"),
         ).where(Invoice.is_transfer == False)  # noqa: E712
+        base = base.where(feature_enabled_filter(FEATURE_COSTS, Invoice.case_id))
         if type:
             base = base.where(Invoice.type == type)
         if case_id:
@@ -563,6 +587,12 @@ def get_cost_summary(case_id: int) -> dict:
     """
     effective_amount = func.coalesce(Invoice.case_amount, Invoice.amount)
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {
+                "total_costs": 0, "our_costs": 0, "counsel_costs": 0,
+                "our_net": 0, "counsel_net": 0, "net_transferred": 0,
+                "counsel_id": None, "counsel_name": None,
+            }
         cost_rows = session.execute(
             select(
                 Invoice.paid_by_person_id,
@@ -683,6 +713,11 @@ def get_cost_sharing(case_id: int) -> dict:
     is configured.
     """
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {
+                "config": None, "co_counsel": [],
+                "parties_with_pct": [], "absorber_party": cs.OURS,
+            }
         rows = session.execute(
             select(PersonRole, Person)
             .join(Person, PersonRole.person_id == Person.id)
@@ -733,6 +768,7 @@ def set_cost_sharing(case_id: int, person_id: int, cost_share_pct: float) -> dic
     Auto-assigns the person as co-counsel on the case if they aren't already.
     """
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_COSTS)
         person = session.get(Person, person_id)
         if not person:
             raise ValueError(f"Person {person_id} not found")
@@ -767,6 +803,7 @@ def set_cost_sharing_config(case_id: int, config: dict) -> dict:
     The caller is responsible for validating `config` (use Pydantic).
     """
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_COSTS)
         case = session.get(Case, case_id)
         if not case:
             raise ValueError(f"Case {case_id} not found")
@@ -805,6 +842,7 @@ def set_cost_sharing_config(case_id: int, config: dict) -> dict:
 def remove_cost_sharing_config(case_id: int) -> dict:
     """Clear the JSONB cost-sharing config and all phase_ids."""
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_COSTS)
         case = session.get(Case, case_id)
         if not case:
             raise ValueError(f"Case {case_id} not found")
@@ -825,21 +863,24 @@ def get_settlement(case_id: int) -> dict:
 
     Requires a JSONB config on the case. Returns empty result if none exists.
     """
+    empty_result = {
+        "parties": [],
+        "targets": {},
+        "paid": {},
+        "net_paid": {},
+        "deltas": {},
+        "transfers": [],
+    }
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return empty_result
         case = session.get(Case, case_id)
         if not case:
             raise ValueError(f"Case {case_id} not found")
 
         config = case.cost_sharing_config
         if not config:
-            return {
-                "parties": [],
-                "targets": {},
-                "paid": {},
-                "net_paid": {},
-                "deltas": {},
-                "transfers": [],
-            }
+            return empty_result
 
         invoices = _load_case_invoices_for_allocation(session, case_id)
         for inv in invoices:
@@ -864,6 +905,11 @@ def get_settlement(case_id: int) -> dict:
 def get_advance_stats(case_id: int) -> dict:
     effective_amount = func.coalesce(Invoice.case_amount, Invoice.amount)
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {
+                "total_advances": 0, "unpaid_count": 0, "paid_count": 0,
+                "by_recipient": [],
+            }
         row = session.execute(
             select(
                 func.coalesce(func.sum(effective_amount), 0).label("total"),

--- a/db/liens.py
+++ b/db/liens.py
@@ -7,6 +7,10 @@ from typing import Optional
 from sqlalchemy import select, func
 
 from .session import SessionLocal
+from .feature_gates import (
+    FEATURE_COSTS, feature_enabled_filter, require_feature_for_case,
+    is_feature_enabled,
+)
 from models import Lien, Case, CaseComment, Payee
 
 
@@ -59,6 +63,7 @@ def list_liens(
         .outerjoin(Payee, Lien.payee_id == Payee.id)
     )
 
+    stmt = stmt.where(feature_enabled_filter(FEATURE_COSTS, Lien.case_id))
     if case_id:
         stmt = stmt.where(Lien.case_id == case_id)
     if status:
@@ -84,19 +89,13 @@ def list_liens(
     else:
         stmt = stmt.order_by(sort_col.asc().nullslast(), Lien.created_at.asc())
 
-    count_stmt = select(func.count()).select_from(select(Lien.id))
+    feature_clause = feature_enabled_filter(FEATURE_COSTS, Lien.case_id)
+    count_inner = select(Lien.id).where(feature_clause)
     if case_id:
-        count_stmt = select(func.count()).select_from(
-            select(Lien.id).where(Lien.case_id == case_id)
-        )
-        if status:
-            count_stmt = select(func.count()).select_from(
-                select(Lien.id).where(Lien.case_id == case_id, Lien.status == status)
-            )
-    elif status:
-        count_stmt = select(func.count()).select_from(
-            select(Lien.id).where(Lien.status == status)
-        )
+        count_inner = count_inner.where(Lien.case_id == case_id)
+    if status:
+        count_inner = count_inner.where(Lien.status == status)
+    count_stmt = select(func.count()).select_from(count_inner.subquery())
 
     with SessionLocal() as session:
         total = session.scalar(count_stmt)
@@ -124,6 +123,8 @@ def get_lien(lien_id: int) -> Optional[dict]:
         if not row:
             return None
         lien, case_name, payee_name, payee_addr = row
+        if not is_feature_enabled(session, lien.case_id, FEATURE_COSTS):
+            return None
         return _lien_to_dict(lien, case_name, payee_name, payee_addr)
 
 
@@ -143,6 +144,7 @@ def create_lien(
     notes: str = None,
 ) -> dict:
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_COSTS)
         lien = Lien(
             case_id=case_id,
             payee_id=payee_id,
@@ -191,6 +193,7 @@ def update_lien(lien_id: int, **fields) -> Optional[dict]:
         lien = session.get(Lien, lien_id)
         if not lien:
             return None
+        require_feature_for_case(session, lien.case_id, FEATURE_COSTS)
 
         for key, value in fields.items():
             if hasattr(lien, key):
@@ -219,6 +222,7 @@ def delete_lien(lien_id: int) -> bool:
         lien = session.get(Lien, lien_id)
         if not lien:
             return False
+        require_feature_for_case(session, lien.case_id, FEATURE_COSTS)
 
         if lien.file_path and os.path.isfile(lien.file_path):
             try:
@@ -233,6 +237,12 @@ def delete_lien(lien_id: int) -> bool:
 
 def get_lien_stats(case_id: int) -> dict:
     with SessionLocal() as session:
+        if not is_feature_enabled(session, case_id, FEATURE_COSTS):
+            return {
+                "count": 0, "pending_count": 0, "negotiated_count": 0,
+                "paid_count": 0, "total_claimed": 0, "total_negotiated": 0,
+                "total_paid": 0, "savings": 0, "savings_pct": 0,
+            }
         row = session.execute(
             select(
                 func.count().label("count"),

--- a/db/tasks.py
+++ b/db/tasks.py
@@ -14,6 +14,10 @@ from .connection import _NOT_PROVIDED
 from .validation import (
     validate_task_status, validate_urgency, validate_date_format
 )
+from .feature_gates import (
+    FEATURE_TASKS, feature_enabled_filter, require_feature_for_case,
+    is_feature_enabled,
+)
 from models import Task, Case, Event, User
 from schemas import TaskOut, UserBriefOut, TaskDetailOut
 
@@ -52,6 +56,8 @@ def add_task(case_id: int = None, description: str = "", due_date: str = None,
     validate_date_format(completion_date, "completion_date")
 
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_TASKS)
+
         # Get max sort_order and add 1000 for new task
         max_order = session.scalar(
             select(func.coalesce(func.max(Task.sort_order), 0))
@@ -116,8 +122,10 @@ def get_tasks(case_id: int = None, status_filter: str = None, exclude_status: st
     )
 
     # Apply filters
+    feature_clause = feature_enabled_filter(FEATURE_TASKS, Task.case_id)
     if case_id:
         stmt = stmt.where(Task.case_id == case_id)
+    stmt = stmt.where(feature_clause)
     if status_filter:
         stmt = stmt.where(Task.status == status_filter)
     if exclude_status:
@@ -144,6 +152,7 @@ def get_tasks(case_id: int = None, status_filter: str = None, exclude_status: st
         count_base = select(Task.id).outerjoin(Case, Task.case_id == Case.id)
         if case_id:
             count_base = count_base.where(Task.case_id == case_id)
+        count_base = count_base.where(feature_clause)
         if status_filter:
             count_base = count_base.where(Task.status == status_filter)
         if exclude_status:
@@ -193,6 +202,7 @@ def update_task(task_id: int, status: str = None, urgency: str = None) -> Option
         task = session.get(Task, task_id)
         if not task:
             return None
+        require_feature_for_case(session, task.case_id, FEATURE_TASKS)
 
         if status:
             task.status = status
@@ -222,6 +232,7 @@ def update_task_full(task_id: int, description: str = _NOT_PROVIDED, due_date: s
         task = session.get(Task, task_id)
         if not task:
             return None
+        require_feature_for_case(session, task.case_id, FEATURE_TASKS)
 
         if description is not _NOT_PROVIDED:
             task.description = description
@@ -282,13 +293,19 @@ def delete_task(task_id: int) -> bool:
         task = session.get(Task, task_id)
         if not task:
             return False
+        require_feature_for_case(session, task.case_id, FEATURE_TASKS)
         session.delete(task)
         session.commit()
         return True
 
 
 def bulk_update_tasks(task_ids: List[int], status: str) -> dict:
-    """Update status for multiple tasks."""
+    """Update status for multiple tasks.
+
+    Tasks belonging to cases with the tasks feature disabled are silently
+    skipped — they're not visible to the user, so they're treated as
+    non-existent for this operation.
+    """
     validate_task_status(status)
     with SessionLocal() as session:
         values = {"status": status}
@@ -297,7 +314,12 @@ def bulk_update_tasks(task_ids: List[int], status: str) -> dict:
         else:
             values["completion_date"] = None
 
-        stmt = update(Task).where(Task.id.in_(task_ids)).values(**values)
+        stmt = (
+            update(Task)
+            .where(Task.id.in_(task_ids))
+            .where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
+            .values(**values)
+        )
         result = session.execute(stmt)
         session.commit()
         return {"updated": result.rowcount}
@@ -310,6 +332,7 @@ def bulk_update_tasks_for_case(case_id: int, status: str, current_status: str = 
         validate_task_status(current_status)
 
     with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_TASKS)
         values = {"status": status}
         if status == "Done":
             values["completion_date"] = datetime.date.today()
@@ -331,6 +354,7 @@ def reschedule_overdue_tasks(new_date: str, task_ids: List[int] = None) -> dict:
 
     If task_ids is provided, only those tasks are updated (scoped to the user's
     current view).  Otherwise all overdue incomplete tasks are updated.
+    Tasks on cases with the tasks feature disabled are skipped.
     """
     validate_date_format(new_date, "new_date")
 
@@ -338,6 +362,7 @@ def reschedule_overdue_tasks(new_date: str, task_ids: List[int] = None) -> dict:
         stmt = (
             update(Task)
             .where(Task.due_date < func.current_date(), Task.status != "Done")
+            .where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
             .values(due_date=new_date)
         )
         if task_ids:
@@ -375,6 +400,7 @@ def search_tasks(query: str = None, case_id: int = None, status: str = None,
         .limit(limit)
     )
 
+    stmt = stmt.where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
     if query:
         stmt = stmt.where(Task.description.ilike(f"%{query}%"))
     if case_id:
@@ -419,6 +445,8 @@ def get_task_detail(task_id: int) -> Optional[dict]:
         if not row:
             return None
         task, case, user = row
+        if task.case_id is not None and not is_feature_enabled(session, task.case_id, FEATURE_TASKS):
+            return None
         return TaskDetailOut(
             id=task.id, case_id=task.case_id,
             case_name=case.case_name if case else None,
@@ -443,6 +471,7 @@ def reorder_task(task_id: int, new_sort_order: int, new_urgency: str = None) -> 
         task = session.get(Task, task_id)
         if not task:
             return None
+        require_feature_for_case(session, task.case_id, FEATURE_TASKS)
 
         task.sort_order = new_sort_order
         if new_urgency is not None:

--- a/frontend/src/pages/cases/components/case-features-menu.tsx
+++ b/frontend/src/pages/cases/components/case-features-menu.tsx
@@ -1,0 +1,85 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Settings02Icon } from "@hugeicons/core-free-icons"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { updateCase } from "@/services/cases"
+import {
+  CASE_FEATURE_DEFINITIONS,
+  isCaseFeatureEnabled,
+  type CaseDetail,
+  type CaseFeatureKey,
+  type CaseFeatureToggles,
+} from "@/types/case"
+
+interface CaseFeaturesMenuProps {
+  caseData: CaseDetail
+}
+
+export function CaseFeaturesMenu({ caseData }: CaseFeaturesMenuProps) {
+  const queryClient = useQueryClient()
+  const toggles = caseData.feature_toggles ?? {}
+
+  const mutation = useMutation({
+    mutationFn: (next: CaseFeatureToggles) =>
+      updateCase(caseData.id, { feature_toggles: next }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["case", caseData.id], data.case)
+      queryClient.invalidateQueries({ queryKey: ["case", caseData.id] })
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  function handleToggle(key: CaseFeatureKey, on: boolean) {
+    const next: CaseFeatureToggles = { ...toggles, [key]: on }
+    mutation.mutate(next)
+  }
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="Case sections"
+            >
+              <HugeiconsIcon icon={Settings02Icon} className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Show/hide sections</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Page sections</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {CASE_FEATURE_DEFINITIONS.map((def) => (
+          <DropdownMenuCheckboxItem
+            key={def.key}
+            checked={isCaseFeatureEnabled(toggles, def.key)}
+            onCheckedChange={(checked) => handleToggle(def.key, !!checked)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            <div className="flex flex-col">
+              <span>{def.label}</span>
+              <span className="text-[10px] text-muted-foreground">
+                {def.description}
+              </span>
+            </div>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/pages/cases/detail.tsx
+++ b/frontend/src/pages/cases/detail.tsx
@@ -33,7 +33,9 @@ import { CaseEventsCard } from "@/pages/cases/components/case-events-card"
 import { AddEventDialog } from "@/pages/cases/components/add-event-dialog"
 import { CaseNotesPanel } from "@/pages/cases/components/case-notes-panel"
 import { CaseFinancialsCard } from "@/pages/cases/components/case-financials-card"
+import { CaseFeaturesMenu } from "@/pages/cases/components/case-features-menu"
 import { ListNav } from "@/components/common/list-nav"
+import { isCaseFeatureEnabled } from "@/types/case"
 
 export default function CaseDetailPage() {
   return (
@@ -192,29 +194,40 @@ function CaseDetailContent() {
     )
   }
 
+  const toggles = caseData.feature_toggles
+  const showTasks = isCaseFeatureEnabled(toggles, "tasks")
+  const showEvents = isCaseFeatureEnabled(toggles, "events")
+  const showFinancials = isCaseFeatureEnabled(toggles, "financials")
+  const showCosts = isCaseFeatureEnabled(toggles, "costs")
+
   return (
     <TooltipProvider>
       <div className="flex flex-col gap-6 p-6">
         <ListNav basePath="/cases" currentId={caseId} />
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
           <CaseDetailHeader caseData={caseData} />
-          <Link
-            to={`/cases/${caseId}/costs`}
-            state={location.state}
-            className="flex items-center gap-3 text-xs shrink-0 border bg-muted/40 px-3 py-1.5"
-          >
-            <span className="text-muted-foreground">Costs</span>
-            {invoiceStats && (
-              <>
-                <span className="text-success tabular-nums">
-                  ${Number(invoiceStats.paid_total).toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                </span>
-                <span className="text-destructive tabular-nums">
-                  ${Number(invoiceStats.unpaid_total).toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                </span>
-              </>
+          <div className="flex items-center gap-2 shrink-0">
+            {showCosts && (
+              <Link
+                to={`/cases/${caseId}/costs`}
+                state={location.state}
+                className="flex items-center gap-3 text-xs border bg-muted/40 px-3 py-1.5"
+              >
+                <span className="text-muted-foreground">Costs</span>
+                {invoiceStats && (
+                  <>
+                    <span className="text-success tabular-nums">
+                      ${Number(invoiceStats.paid_total).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                    </span>
+                    <span className="text-destructive tabular-nums">
+                      ${Number(invoiceStats.unpaid_total).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                    </span>
+                  </>
+                )}
+              </Link>
             )}
-          </Link>
+            <CaseFeaturesMenu caseData={caseData} />
+          </div>
         </div>
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-5">
@@ -227,18 +240,24 @@ function CaseDetailContent() {
               onAiPeople={() => setAiPeopleOpen(true)}
               onNest={handleNest}
             />
-            <CaseTasksCard
-              caseId={caseData.id}
-              onAdd={() => setAddTaskOpen(true)}
-              onAiAdd={() => setAiTasksOpen(true)}
-            />
-            <CaseEventsCard
-              caseId={caseData.id}
-              onAdd={() => setAddEventOpen(true)}
-              onAiAdd={() => setAiEventsOpen(true)}
-            />
+            {showTasks && (
+              <CaseTasksCard
+                caseId={caseData.id}
+                onAdd={() => setAddTaskOpen(true)}
+                onAiAdd={() => setAiTasksOpen(true)}
+              />
+            )}
+            {showEvents && (
+              <CaseEventsCard
+                caseId={caseData.id}
+                onAdd={() => setAddEventOpen(true)}
+                onAiAdd={() => setAiEventsOpen(true)}
+              />
+            )}
             <CaseNotesPanel caseId={caseData.id} notes={caseData.notes} />
-            <CaseFinancialsCard caseId={caseData.id} casePersons={caseData.persons} />
+            {showFinancials && (
+              <CaseFinancialsCard caseId={caseData.id} casePersons={caseData.persons} />
+            )}
 
             {user?.isAdmin && (
               <div className="flex justify-end pt-4 border-t border-border/40">

--- a/frontend/src/services/cases.ts
+++ b/frontend/src/services/cases.ts
@@ -81,6 +81,7 @@ export type UpdateCaseData = Partial<CreateCaseData> & {
   trial_likelihood?: number | null
   trial_likelihood_note?: string | null
   trial_estimated_days?: number | null
+  feature_toggles?: Record<string, boolean> | null
 }
 
 export async function updateCase(

--- a/frontend/src/types/case.ts
+++ b/frontend/src/types/case.ts
@@ -68,6 +68,29 @@ export interface CaseDetail {
   tasks: CaseTask[]
   notes: string | null
   proceedings: CaseProceeding[]
+  feature_toggles: CaseFeatureToggles | null
+}
+
+export type CaseFeatureKey = "tasks" | "events" | "financials" | "costs"
+
+export type CaseFeatureToggles = Partial<Record<CaseFeatureKey, boolean>>
+
+export const CASE_FEATURE_DEFINITIONS: {
+  key: CaseFeatureKey
+  label: string
+  description: string
+}[] = [
+  { key: "tasks", label: "Tasks", description: "Track to-dos on this case" },
+  { key: "events", label: "Events", description: "Calendar dates and deadlines" },
+  { key: "financials", label: "Financials", description: "Settlement & disbursement summary" },
+  { key: "costs", label: "Costs", description: "Costs/invoices link and totals" },
+]
+
+export function isCaseFeatureEnabled(
+  toggles: CaseFeatureToggles | null | undefined,
+  key: CaseFeatureKey
+): boolean {
+  return toggles?.[key] === true
 }
 
 export interface CaseStaffUser {

--- a/models.py
+++ b/models.py
@@ -304,6 +304,11 @@ class Case(Base):
     # N parties, phases, and caps. See db/cost_sharing.py.
     cost_sharing_config: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
 
+    # Per-case visibility toggles for optional page sections (tasks, events,
+    # financials, costs, etc.). When NULL or a key is missing, the section is
+    # OFF. Shared across the team — turning a section on shows it for everyone.
+    feature_toggles: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+
     # Relationships
     comments: Mapped[list[CaseComment]] = relationship(back_populates="case", passive_deletes=True)
     events: Mapped[list[Event]] = relationship(back_populates="case", passive_deletes=True)

--- a/routes/common.py
+++ b/routes/common.py
@@ -43,3 +43,19 @@ def pydantic_error(exc) -> JSONResponse:
         {"success": False, "error": {"message": summary, "code": "VALIDATION_ERROR", "details": details}},
         status_code=422,
     )
+
+
+def feature_disabled_error(exc) -> JSONResponse:
+    """Convert a db.FeatureDisabled exception to a 403 JSON response."""
+    return JSONResponse(
+        {
+            "success": False,
+            "error": {
+                "message": str(exc),
+                "code": "FEATURE_DISABLED",
+                "feature": exc.feature,
+                "case_id": exc.case_id,
+            },
+        },
+        status_code=403,
+    )

--- a/routes/events.py
+++ b/routes/events.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 import db
 import auth
 from schemas import CreateEventInput, UpdateEventInput
-from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
+from .common import api_error, pydantic_error, feature_disabled_error, DEFAULT_PAGE_SIZE
 
 
 def register_event_routes(mcp):
@@ -57,20 +57,23 @@ def register_event_routes(mcp):
             data = CreateEventInput(**(await request.json()))
         except ValidationError as e:
             return pydantic_error(e)
-        result = await asyncio.to_thread(
-            db.add_event,
-            data.case_id,
-            data.date,
-            data.description,
-            data.document_link,
-            data.calculation_note,
-            data.time,
-            data.location,
-            data.starred,
-            data.event_type,
-            data.end_date,
-            data.blocks_calendar,
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.add_event,
+                data.case_id,
+                data.date,
+                data.description,
+                data.document_link,
+                data.calculation_note,
+                data.time,
+                data.location,
+                data.starred,
+                data.event_type,
+                data.end_date,
+                data.blocks_calendar,
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
 
         # System comment for event creation
         user = auth.get_current_user(request)
@@ -126,7 +129,10 @@ def register_event_routes(mcp):
         except ValidationError as e:
             return pydantic_error(e)
         updates = data.model_dump(exclude_none=True)
-        result = await asyncio.to_thread(db.update_event_full, event_id, **updates)
+        try:
+            result = await asyncio.to_thread(db.update_event_full, event_id, **updates)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Event not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "event": result})
@@ -146,7 +152,10 @@ def register_event_routes(mcp):
         if err := auth.require_auth(request):
             return err
         event_id = int(request.path_params["event_id"])
-        deleted = await asyncio.to_thread(db.delete_event, event_id)
+        try:
+            deleted = await asyncio.to_thread(db.delete_event, event_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if deleted:
             return JSONResponse({"success": True})
         return api_error("Event not found", "NOT_FOUND", 404)
@@ -171,7 +180,10 @@ def register_event_routes(mcp):
             return err
         event_id = int(request.path_params["event_id"])
         user_id = int(request.path_params["user_id"])
-        result = await asyncio.to_thread(db.add_event_attendee, event_id, user_id)
+        try:
+            result = await asyncio.to_thread(db.add_event_attendee, event_id, user_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result.get("success"):
             return api_error(result.get("error", "Failed to add attendee"), "ADD_FAILED", 400)
         return JSONResponse({"success": True, "data": result})
@@ -183,7 +195,10 @@ def register_event_routes(mcp):
             return err
         event_id = int(request.path_params["event_id"])
         user_id = int(request.path_params["user_id"])
-        result = await asyncio.to_thread(db.remove_event_attendee, event_id, user_id)
+        try:
+            result = await asyncio.to_thread(db.remove_event_attendee, event_id, user_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result.get("success"):
             return api_error(result.get("error", "Failed to remove attendee"), "REMOVE_FAILED", 400)
         return JSONResponse({"success": True, "data": result})

--- a/routes/financials.py
+++ b/routes/financials.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 import db
 import auth
 from schemas import CreateFinancialInput, UpdateFinancialInput
-from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
+from .common import api_error, pydantic_error, feature_disabled_error, DEFAULT_PAGE_SIZE
 
 
 def register_financial_routes(mcp):
@@ -98,11 +98,14 @@ def register_financial_routes(mcp):
             data = CreateFinancialInput(**(await request.json()))
         except ValidationError as e:
             return pydantic_error(e)
-        result = await asyncio.to_thread(
-            db.create_financial,
-            data.case_id,
-            **data.model_dump(exclude={"case_id"}, exclude_none=True),
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.create_financial,
+                data.case_id,
+                **data.model_dump(exclude={"case_id"}, exclude_none=True),
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         return JSONResponse({"success": True, "financial": result})
 
     @mcp.custom_route("/api/v1/financials/{financial_id}", methods=["PUT"])
@@ -116,7 +119,10 @@ def register_financial_routes(mcp):
         except ValidationError as e:
             return pydantic_error(e)
         updates = data.model_dump(exclude_none=True)
-        result = await asyncio.to_thread(db.update_financial, financial_id, **updates)
+        try:
+            result = await asyncio.to_thread(db.update_financial, financial_id, **updates)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Financial record not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "financial": result})
@@ -127,7 +133,10 @@ def register_financial_routes(mcp):
         if err := auth.require_auth(request):
             return err
         financial_id = int(request.path_params["financial_id"])
-        deleted = await asyncio.to_thread(db.delete_financial, financial_id)
+        try:
+            deleted = await asyncio.to_thread(db.delete_financial, financial_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if deleted:
             return JSONResponse({"success": True})
         return api_error("Financial record not found", "NOT_FOUND", 404)
@@ -143,9 +152,12 @@ def register_financial_routes(mcp):
             return err
         financial_id = int(request.path_params["financial_id"])
         body = await request.json()
-        result = await asyncio.to_thread(
-            db.create_counsel_fee, financial_id, **body
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.create_counsel_fee, financial_id, **body
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         return JSONResponse({"success": True, "financial": result})
 
     @mcp.custom_route("/api/v1/counsel-fees/{fee_id}", methods=["PUT"])
@@ -155,7 +167,10 @@ def register_financial_routes(mcp):
             return err
         fee_id = int(request.path_params["fee_id"])
         body = await request.json()
-        result = await asyncio.to_thread(db.update_counsel_fee, fee_id, **body)
+        try:
+            result = await asyncio.to_thread(db.update_counsel_fee, fee_id, **body)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Counsel fee not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "financial": result})
@@ -166,7 +181,10 @@ def register_financial_routes(mcp):
         if err := auth.require_auth(request):
             return err
         fee_id = int(request.path_params["fee_id"])
-        result = await asyncio.to_thread(db.delete_counsel_fee, fee_id)
+        try:
+            result = await asyncio.to_thread(db.delete_counsel_fee, fee_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Counsel fee not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "financial": result})

--- a/routes/invoices.py
+++ b/routes/invoices.py
@@ -18,7 +18,7 @@ from schemas import (
     MarkInvoicePaidInput,
     CostSharingConfigInput,
 )
-from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
+from .common import api_error, pydantic_error, feature_disabled_error, DEFAULT_PAGE_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -171,9 +171,12 @@ def register_invoice_routes(mcp):
         cost_share_pct = body.get("cost_share_pct")
         if person_id is None or cost_share_pct is None:
             return api_error("person_id and cost_share_pct are required", "VALIDATION_ERROR", 400)
-        result = await asyncio.to_thread(
-            db.set_cost_sharing, case_id, int(person_id), float(cost_share_pct)
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.set_cost_sharing, case_id, int(person_id), float(cost_share_pct)
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         return JSONResponse(result)
 
     @mcp.custom_route("/api/v1/cases/{case_id}/cost-sharing", methods=["DELETE"])
@@ -184,6 +187,8 @@ def register_invoice_routes(mcp):
         try:
             result = await asyncio.to_thread(db.remove_cost_sharing, case_id)
             return JSONResponse(result)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         except ValueError as e:
             return api_error(str(e), "VALIDATION_ERROR", 400)
 
@@ -201,6 +206,8 @@ def register_invoice_routes(mcp):
                 db.set_cost_sharing_config, case_id, data.model_dump()
             )
             return JSONResponse(result)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         except ValueError as e:
             return api_error(str(e), "VALIDATION_ERROR", 400)
 
@@ -212,6 +219,8 @@ def register_invoice_routes(mcp):
         try:
             result = await asyncio.to_thread(db.remove_cost_sharing_config, case_id)
             return JSONResponse(result)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         except ValueError as e:
             return api_error(str(e), "VALIDATION_ERROR", 400)
 
@@ -268,12 +277,15 @@ def register_invoice_routes(mcp):
         except ValidationError as e:
             return pydantic_error(e)
 
-        result = await asyncio.to_thread(
-            db.create_invoice,
-            data.case_id,
-            data.amount,
-            **data.model_dump(exclude={"case_id", "amount"}, exclude_none=True),
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.create_invoice,
+                data.case_id,
+                data.amount,
+                **data.model_dump(exclude={"case_id", "amount"}, exclude_none=True),
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         return JSONResponse({"success": True, "invoice": result})
 
     @mcp.custom_route("/api/v1/invoices/{invoice_id}", methods=["PUT"])
@@ -287,7 +299,10 @@ def register_invoice_routes(mcp):
             return pydantic_error(e)
 
         updates = data.model_dump(exclude_unset=True)
-        result = await asyncio.to_thread(db.update_invoice, invoice_id, **updates)
+        try:
+            result = await asyncio.to_thread(db.update_invoice, invoice_id, **updates)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Invoice not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "invoice": result})
@@ -302,12 +317,15 @@ def register_invoice_routes(mcp):
         except ValidationError as e:
             return pydantic_error(e)
 
-        result = await asyncio.to_thread(
-            db.mark_invoice_paid,
-            invoice_id,
-            check_number=data.check_number,
-            paid_date=data.paid_date,
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.mark_invoice_paid,
+                invoice_id,
+                check_number=data.check_number,
+                paid_date=data.paid_date,
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Invoice not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "invoice": result})
@@ -317,7 +335,10 @@ def register_invoice_routes(mcp):
         if err := auth.require_auth(request):
             return err
         invoice_id = int(request.path_params["invoice_id"])
-        result = await asyncio.to_thread(db.mark_invoice_unpaid, invoice_id)
+        try:
+            result = await asyncio.to_thread(db.mark_invoice_unpaid, invoice_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Invoice not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "invoice": result})
@@ -327,7 +348,10 @@ def register_invoice_routes(mcp):
         if err := auth.require_auth(request):
             return err
         invoice_id = int(request.path_params["invoice_id"])
-        deleted = await asyncio.to_thread(db.delete_invoice, invoice_id)
+        try:
+            deleted = await asyncio.to_thread(db.delete_invoice, invoice_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if deleted:
             return JSONResponse({"success": True})
         return api_error("Invoice not found", "NOT_FOUND", 404)

--- a/routes/liens.py
+++ b/routes/liens.py
@@ -13,7 +13,7 @@ import auth
 import db
 from config import settings
 from schemas import CreateLienInput, UpdateLienInput
-from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
+from .common import api_error, pydantic_error, feature_disabled_error, DEFAULT_PAGE_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -123,12 +123,15 @@ def register_lien_routes(mcp):
         except ValidationError as e:
             return pydantic_error(e)
 
-        result = await asyncio.to_thread(
-            db.create_lien,
-            data.case_id,
-            data.claimed_amount,
-            **data.model_dump(exclude={"case_id", "claimed_amount"}, exclude_none=True),
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.create_lien,
+                data.case_id,
+                data.claimed_amount,
+                **data.model_dump(exclude={"case_id", "claimed_amount"}, exclude_none=True),
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         return JSONResponse({"success": True, "lien": result})
 
     @mcp.custom_route("/api/v1/liens/{lien_id}", methods=["PUT"])
@@ -142,7 +145,10 @@ def register_lien_routes(mcp):
             return pydantic_error(e)
 
         updates = data.model_dump(exclude_unset=True)
-        result = await asyncio.to_thread(db.update_lien, lien_id, **updates)
+        try:
+            result = await asyncio.to_thread(db.update_lien, lien_id, **updates)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Lien not found", "NOT_FOUND", 404)
         return JSONResponse({"success": True, "lien": result})
@@ -152,7 +158,10 @@ def register_lien_routes(mcp):
         if err := auth.require_auth(request):
             return err
         lien_id = int(request.path_params["lien_id"])
-        deleted = await asyncio.to_thread(db.delete_lien, lien_id)
+        try:
+            deleted = await asyncio.to_thread(db.delete_lien, lien_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if deleted:
             return JSONResponse({"success": True})
         return api_error("Lien not found", "NOT_FOUND", 404)

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -11,7 +11,7 @@ import db
 import auth
 from db.comments import add_comment as add_entity_comment
 from schemas import CreateTaskInput, UpdateTaskInput
-from .common import api_error, pydantic_error, DEFAULT_PAGE_SIZE
+from .common import api_error, pydantic_error, feature_disabled_error, DEFAULT_PAGE_SIZE
 from .comments import _get_db_user_id
 from .sse import broadcast
 
@@ -61,17 +61,20 @@ def register_task_routes(mcp):
             data = CreateTaskInput(**(await request.json()))
         except ValidationError as e:
             return pydantic_error(e)
-        result = await asyncio.to_thread(
-            db.add_task,
-            data.case_id,
-            data.description,
-            data.due_date,
-            data.status,
-            data.urgency,
-            data.event_id,
-            data.assignee_id,
-            data.completion_date,
-        )
+        try:
+            result = await asyncio.to_thread(
+                db.add_task,
+                data.case_id,
+                data.description,
+                data.due_date,
+                data.status,
+                data.urgency,
+                data.event_id,
+                data.assignee_id,
+                data.completion_date,
+            )
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
 
         # System comments for task creation
         user = auth.get_current_user(request)
@@ -129,7 +132,10 @@ def register_task_routes(mcp):
             return api_error("Task not found", "NOT_FOUND", 404)
 
         updates = data.model_dump(exclude_unset=True)
-        result = await asyncio.to_thread(db.update_task_full, task_id, **updates)
+        try:
+            result = await asyncio.to_thread(db.update_task_full, task_id, **updates)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if not result:
             return api_error("Task not found", "NOT_FOUND", 404)
 
@@ -195,7 +201,10 @@ def register_task_routes(mcp):
         if err := auth.require_auth(request):
             return err
         task_id = int(request.path_params["task_id"])
-        deleted = await asyncio.to_thread(db.delete_task, task_id)
+        try:
+            deleted = await asyncio.to_thread(db.delete_task, task_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         if deleted:
             return JSONResponse({"success": True})
         return api_error("Task not found", "NOT_FOUND", 404)
@@ -223,6 +232,8 @@ def register_task_routes(mcp):
             if not result:
                 return api_error("Task not found", "NOT_FOUND", 404)
             return JSONResponse({"success": True, "task": result})
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
         except db.ValidationError as e:
             return api_error(str(e), "VALIDATION_ERROR", 400)
 

--- a/schemas/inputs.py
+++ b/schemas/inputs.py
@@ -4,7 +4,7 @@ Pydantic input models for create/update operations.
 Used by both MCP tools and REST routes.
 """
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .common import CaseStatus, TaskStatus, Urgency, IntakeStatus, ResolutionType
@@ -43,6 +43,7 @@ class UpdateCaseInput(BaseModel):
     claim_deadline: Optional[str] = None
     complaint_deadline: Optional[str] = None
     notes: Optional[str] = None
+    feature_toggles: Optional[dict[str, Any]] = None
 
 
 # =============================================================================

--- a/schemas/outputs.py
+++ b/schemas/outputs.py
@@ -485,6 +485,7 @@ class CaseDetailOut(BaseModel):
     tasks: list[dict] = []
     notes: list[dict] = []
     proceedings: list[dict] = []
+    feature_toggles: Optional[dict] = None
 
 
 class CaseSearchOut(BaseModel):

--- a/tools.py
+++ b/tools.py
@@ -1031,6 +1031,10 @@ def register_tools(mcp):
 
         except ValidationError as e:
             return validation_error(str(e))
+        except db.FeatureDisabled as e:
+            return error_response(str(e), "FEATURE_DISABLED",
+                                  hint=f"Events are disabled for case {e.case_id}.",
+                                  suggestion="Ask the user to enable Events from the gear menu on the case page.")
         except Exception as e:
             return error_response(f"manage_event failed: {str(e)}", "MUTATION_ERROR")
 
@@ -1100,6 +1104,10 @@ def register_tools(mcp):
 
         except ValidationError as e:
             return validation_error(str(e))
+        except db.FeatureDisabled as e:
+            return error_response(str(e), "FEATURE_DISABLED",
+                                  hint=f"Tasks are disabled for case {e.case_id}.",
+                                  suggestion="Ask the user to enable Tasks from the gear menu on the case page.")
         except Exception as e:
             return error_response(f"manage_task failed: {str(e)}", "MUTATION_ERROR")
 


### PR DESCRIPTION
Adds a feature_toggles JSONB column on cases and a gear-icon menu in the
case detail header to show/hide optional sections (Tasks, Events,
Financials, Costs). All four are off by default so new cases just show
proceedings, people, dates, status, assignees, notes, and the activity
feed — toggleable per case and shared across the team.