### PR TITLE
Simplify trial calendar mobile view and drop case color swatch

### DIFF
--- a/frontend/src/pages/cases/components/trial-edit-cell.tsx
+++ b/frontend/src/pages/cases/components/trial-edit-cell.tsx
@@ -95,7 +95,6 @@ export function TrialEditCell({
 
   const days = daysUntil(trialDate)
   const isPast = days != null && days < 0
-  const isUrgent = days != null && days >= 0 && days <= 90
 
   return (
     <Popover open={open} onOpenChange={handleOpen}>
@@ -110,11 +109,7 @@ export function TrialEditCell({
               <div className="flex items-center gap-1.5">
                 <span
                   className={
-                    isPast
-                      ? "text-destructive font-medium text-sm"
-                      : isUrgent
-                        ? "text-warning-foreground font-medium text-sm"
-                        : "text-sm"
+                    isPast ? "text-destructive font-medium text-sm" : "text-sm"
                   }
                 >
                   {formatDate(trialDate)}

--- a/frontend/src/pages/trial-calendar/components/trial-columns.tsx
+++ b/frontend/src/pages/trial-calendar/components/trial-columns.tsx
@@ -62,16 +62,10 @@ export function getTrialColumns(options: {
       ),
       cell: ({ row }) => {
         if (row.original.kind === "trial") {
-          const { color, case_name, status } = row.original.trial
+          const { case_name, status } = row.original.trial
           const isStale = STALE_STATUSES.has(status)
           return (
             <div className="flex items-center gap-2">
-              {color && (
-                <span
-                  className="inline-block size-2.5 shrink-0"
-                  style={{ backgroundColor: `var(--palette-${color})` }}
-                />
-              )}
               <span className="font-medium">{case_name}</span>
               {isStale && (
                 <Tooltip>

--- a/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
+++ b/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
@@ -16,12 +16,6 @@ function parseDate(s: string): Date {
   return new Date(y, m - 1, d)
 }
 
-function daysUntil(dateStr: string): number {
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
-  return Math.ceil((parseDate(dateStr).getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-}
-
 export function TrialListMobile({
   trials,
   blockingEvents,
@@ -54,9 +48,6 @@ export function TrialListMobile({
       {rows.map((row) => {
         if (row.kind === "trial") {
           const t = row.trial
-          const days = daysUntil(t.trial_date)
-          const dateColor =
-            days < 0 ? "text-destructive" : days <= 90 ? "text-warning-foreground" : "text-foreground"
           return (
             <button
               key={`trial-${t.case_id}`}
@@ -83,7 +74,7 @@ export function TrialListMobile({
                 </div>
               )}
               <span className="min-w-0 flex-1 truncate font-medium">{t.case_name}</span>
-              <span className={`shrink-0 text-sm tabular-nums ${dateColor}`}>
+              <span className="shrink-0 text-sm tabular-nums">
                 {format(parseDate(t.trial_date), "MMM d, yyyy")}
               </span>
             </button>

--- a/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
+++ b/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from "react"
+import { format } from "date-fns"
+import { useNavigate } from "react-router"
+import type { TrialItem, BlockingEvent } from "@/services/trial-calendar"
+import type { StaffMember } from "@/services/staff"
+import { getAvatarStyleById } from "@/lib/badge-colors"
+import { getEventTypeLabel, getEventTypeColor } from "@/lib/event-types"
+import { Badge } from "@/components/ui/badge"
+
+type Row =
+  | { kind: "trial"; date: string; trial: TrialItem }
+  | { kind: "event"; date: string; event: BlockingEvent }
+
+function parseDate(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number)
+  return new Date(y, m - 1, d)
+}
+
+function daysUntil(dateStr: string): number {
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  return Math.ceil((parseDate(dateStr).getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+}
+
+export function TrialListMobile({
+  trials,
+  blockingEvents,
+  staffMap,
+  onEditEvent,
+}: {
+  trials: TrialItem[]
+  blockingEvents: BlockingEvent[]
+  staffMap: Map<number, StaffMember>
+  onEditEvent?: (event: BlockingEvent) => void
+}) {
+  const navigate = useNavigate()
+
+  const rows = useMemo<Row[]>(() => {
+    const trialRows: Row[] = trials.map((t) => ({ kind: "trial", date: t.trial_date, trial: t }))
+    const eventRows: Row[] = blockingEvents.map((e) => ({ kind: "event", date: e.date, event: e }))
+    return [...trialRows, ...eventRows].sort((a, b) => a.date.localeCompare(b.date))
+  }, [trials, blockingEvents])
+
+  if (!rows.length) {
+    return (
+      <div className="border p-6 text-center text-sm text-muted-foreground">
+        No upcoming items.
+      </div>
+    )
+  }
+
+  return (
+    <div className="border divide-y">
+      {rows.map((row) => {
+        if (row.kind === "trial") {
+          const t = row.trial
+          const days = daysUntil(t.trial_date)
+          const dateColor =
+            days < 0 ? "text-destructive" : days <= 90 ? "text-warning-foreground" : "text-foreground"
+          return (
+            <button
+              key={`trial-${t.case_id}`}
+              type="button"
+              className="flex w-full items-center gap-3 p-3 text-left active:bg-muted/50"
+              onClick={() => navigate(`/cases/${t.case_id}`)}
+            >
+              {t.attorney_ids.length > 0 && (
+                <div className="flex shrink-0 gap-1">
+                  {t.attorney_ids.map((id) => {
+                    const s = staffMap.get(id)
+                    if (!s) return null
+                    return (
+                      <span
+                        key={id}
+                        className="inline-flex size-5 shrink-0 items-center justify-center text-[9px] font-medium"
+                        style={getAvatarStyleById(id)}
+                        title={`${s.firstName} ${s.lastName}`}
+                      >
+                        {s.initials}
+                      </span>
+                    )
+                  })}
+                </div>
+              )}
+              <span className="min-w-0 flex-1 truncate font-medium">{t.case_name}</span>
+              <span className={`shrink-0 text-sm tabular-nums ${dateColor}`}>
+                {format(parseDate(t.trial_date), "MMM d, yyyy")}
+              </span>
+            </button>
+          )
+        }
+
+        const evt = row.event
+        return (
+          <button
+            key={`event-${evt.id}`}
+            type="button"
+            className="flex w-full items-center gap-3 p-3 text-left active:bg-muted/50"
+            onClick={() => onEditEvent?.(evt)}
+          >
+            <Badge
+              variant="outline"
+              className="shrink-0 border-transparent px-1.5 py-0 text-[10px] font-normal text-white"
+              style={{ backgroundColor: getEventTypeColor(evt.event_type) }}
+            >
+              {getEventTypeLabel(evt.event_type)}
+            </Badge>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">{evt.description}</span>
+            <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+              {format(parseDate(evt.date), "MMM d")}
+              {evt.end_date && ` – ${format(parseDate(evt.end_date), "MMM d")}`}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/pages/trial-calendar/index.tsx
+++ b/frontend/src/pages/trial-calendar/index.tsx
@@ -14,6 +14,7 @@ import { createEvent, type CreateEventData } from "@/services/events"
 import { downloadBlob } from "@/lib/download"
 import { getStaff, type StaffMember } from "@/services/staff"
 import { TrialTable } from "@/pages/trial-calendar/components/trial-table"
+import { TrialListMobile } from "@/pages/trial-calendar/components/trial-list-mobile"
 import { SlotFinder } from "@/pages/trial-calendar/components/slot-finder"
 import { AddBlockingEventDialog } from "@/pages/trial-calendar/components/add-blocking-event-dialog"
 import { EditEventDialog } from "@/pages/trial-calendar/components/edit-event-dialog"
@@ -182,7 +183,14 @@ export default function TrialCalendarPage() {
         view === "calendar" ? (
           <LinearCalendar data={data} staffMap={staffMap} onEditEvent={setEditingEvent} />
         ) : (
-          <TrialTable trials={data.trials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
+          <>
+            <div className="hidden md:block">
+              <TrialTable trials={data.trials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
+            </div>
+            <div className="md:hidden">
+              <TrialListMobile trials={data.trials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
+            </div>
+          </>
         )
       ) : null}
 

--- a/frontend/src/pages/trial-calendar/index.tsx
+++ b/frontend/src/pages/trial-calendar/index.tsx
@@ -13,6 +13,7 @@ import { getTrialCalendar, downloadTrialCalendarPdf } from "@/services/trial-cal
 import { createEvent, type CreateEventData } from "@/services/events"
 import { downloadBlob } from "@/lib/download"
 import { getStaff, type StaffMember } from "@/services/staff"
+import { getDateKey } from "@/lib/datetime"
 import { TrialTable } from "@/pages/trial-calendar/components/trial-table"
 import { TrialListMobile } from "@/pages/trial-calendar/components/trial-list-mobile"
 import { SlotFinder } from "@/pages/trial-calendar/components/slot-finder"
@@ -74,6 +75,13 @@ export default function TrialCalendarPage() {
     for (const s of staffData?.data ?? []) map.set(s.id, s)
     return map
   }, [staffData])
+
+  // Trial calendar is forward-looking — drop trials whose date is in the past.
+  const upcomingTrials = useMemo(() => {
+    if (!data) return []
+    const todayKey = getDateKey(new Date().toISOString())
+    return data.trials.filter((t) => t.trial_date >= todayKey)
+  }, [data])
 
   const createEventMutation = useMutation({
     mutationFn: (eventData: CreateEventData) => createEvent(eventData),
@@ -185,10 +193,10 @@ export default function TrialCalendarPage() {
         ) : (
           <>
             <div className="hidden md:block">
-              <TrialTable trials={data.trials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
+              <TrialTable trials={upcomingTrials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
             </div>
             <div className="md:hidden">
-              <TrialListMobile trials={data.trials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
+              <TrialListMobile trials={upcomingTrials} blockingEvents={data.blocking_events} staffMap={staffMap} onEditEvent={setEditingEvent} />
             </div>
           </>
         )


### PR DESCRIPTION
Mobile now renders a compact list (team badge, case name, simple date)
instead of the full editable table, and the color block before the case
name is removed on desktop.

https://claude.ai/code/session_01G7omq6UxcbDTXd8oqeQ98Z