### PR TITLE
Add append-only token usage logging for Claude API calls

### DIFF
--- a/alembic/versions/639396e1dc67_add_token_usage_log_table.py
+++ b/alembic/versions/639396e1dc67_add_token_usage_log_table.py
@@ -1,0 +1,53 @@
+"""add token_usage_log table
+
+Revision ID: 639396e1dc67
+Revises: c1ac1736501b
+Create Date: 2026-05-23 23:44:43.328085
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '639396e1dc67'
+down_revision: Union[str, Sequence[str], None] = 'c1ac1736501b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'token_usage_log',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True),
+        sa.Column('source', sa.String(length=50), nullable=False),
+        sa.Column('request_type', sa.String(length=64), nullable=True),
+        sa.Column('model', sa.String(length=100), nullable=True),
+        sa.Column('input_tokens', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('output_tokens', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('cache_creation_input_tokens', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('cache_read_input_tokens', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('estimated_cost_usd', sa.Numeric(precision=12, scale=6), nullable=True),
+        sa.Column('case_id', sa.Integer(), nullable=True),
+        sa.Column('username', sa.String(length=255), nullable=True),
+        sa.Column('conversation_id', sa.String(length=64), nullable=True),
+        sa.Column('duration_ms', sa.Integer(), nullable=True),
+        sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.PrimaryKeyConstraint('id', name='token_usage_log_pkey'),
+    )
+    op.create_index('idx_token_usage_log_created_at', 'token_usage_log', ['created_at'], unique=False)
+    op.create_index('idx_token_usage_log_source', 'token_usage_log', ['source'], unique=False)
+    op.create_index('idx_token_usage_log_request_type', 'token_usage_log', ['request_type'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_token_usage_log_request_type', table_name='token_usage_log')
+    op.drop_index('idx_token_usage_log_source', table_name='token_usage_log')
+    op.drop_index('idx_token_usage_log_created_at', table_name='token_usage_log')
+    op.drop_table('token_usage_log')

--- a/db/token_usage.py
+++ b/db/token_usage.py
@@ -1,0 +1,129 @@
+"""Append-only token-usage logging for Claude API calls.
+
+`record_usage()` writes one row per API request to `token_usage_log`. It is
+intentionally best-effort: any failure is swallowed and logged at WARNING, so a
+logging problem can never break a chat response or an extraction. Keep the
+single INSERT off the request's critical path (e.g. after the response has been
+flushed to the client, or via ``asyncio.to_thread`` in async code).
+
+Pricing below is USD per 1M tokens, keyed by a substring of the model id.
+Update it when Anthropic pricing changes — existing rows keep the cost snapshot
+that was computed at request time, so history stays accurate.
+"""
+
+import logging
+from typing import Any, Optional
+
+from sqlalchemy import insert
+
+from db.session import SessionLocal
+from models import TokenUsageLog
+
+_logger = logging.getLogger("db.token_usage")
+
+# USD per 1,000,000 tokens. Matched by substring against the model id.
+_PRICING = {
+    "haiku": {"input": 0.80, "output": 4.00, "cache_write": 1.00, "cache_read": 0.08},
+    "sonnet": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30},
+    "opus": {"input": 15.00, "output": 75.00, "cache_write": 18.75, "cache_read": 1.50},
+}
+
+
+def _estimate_cost_usd(
+    model: Optional[str],
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_input_tokens: int,
+    cache_read_input_tokens: int,
+) -> Optional[float]:
+    """Best-effort cost snapshot. Returns None if the model isn't in _PRICING."""
+    m = (model or "").lower()
+    rates = next((r for key, r in _PRICING.items() if key in m), None)
+    if not rates:
+        return None
+    return round(
+        (input_tokens / 1_000_000) * rates["input"]
+        + (output_tokens / 1_000_000) * rates["output"]
+        + (cache_creation_input_tokens / 1_000_000) * rates["cache_write"]
+        + (cache_read_input_tokens / 1_000_000) * rates["cache_read"],
+        6,
+    )
+
+
+def record_usage(
+    *,
+    source: str,
+    request_type: Optional[str] = None,
+    model: Optional[str] = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    case_id: Optional[int] = None,
+    username: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+    duration_ms: Optional[int] = None,
+    meta: Optional[dict[str, Any]] = None,
+) -> None:
+    """Persist one token-usage record. Never raises."""
+    try:
+        input_tokens = input_tokens or 0
+        output_tokens = output_tokens or 0
+        cache_creation_input_tokens = cache_creation_input_tokens or 0
+        cache_read_input_tokens = cache_read_input_tokens or 0
+        cost = _estimate_cost_usd(
+            model,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        )
+        with SessionLocal() as session:
+            session.execute(
+                insert(TokenUsageLog).values(
+                    source=source,
+                    request_type=request_type,
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cache_creation_input_tokens=cache_creation_input_tokens,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    estimated_cost_usd=cost,
+                    case_id=case_id if isinstance(case_id, int) else None,
+                    username=username,
+                    conversation_id=conversation_id,
+                    duration_ms=duration_ms,
+                    meta=meta,
+                )
+            )
+            session.commit()
+    except Exception:
+        _logger.warning("Failed to record token usage (source=%s)", source, exc_info=True)
+
+
+def record_usage_from_message(
+    *,
+    source: str,
+    model: Optional[str] = None,
+    request_type: Optional[str] = None,
+    message: Any,
+    **kwargs: Any,
+) -> None:
+    """Pull `.usage` off a non-streaming Anthropic message and record it.
+
+    Extra keyword args (case_id, username, duration_ms, meta, ...) pass through
+    to record_usage. Never raises.
+    """
+    usage = getattr(message, "usage", None)
+    if usage is None:
+        return
+    record_usage(
+        source=source,
+        request_type=request_type,
+        model=model,
+        input_tokens=getattr(usage, "input_tokens", 0) or 0,
+        output_tokens=getattr(usage, "output_tokens", 0) or 0,
+        cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+        **kwargs,
+    )

--- a/models.py
+++ b/models.py
@@ -1411,3 +1411,45 @@ class CommentRead(Base):
     last_read_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime(timezone=True), server_default=text("CURRENT_TIMESTAMP")
     )
+
+
+class TokenUsageLog(Base):
+    """Append-only record of Claude API token consumption, one row per request.
+
+    Decoupled analytics log: no FK constraints (a deleted case must never
+    cascade into or block this table), written best-effort off the request's
+    critical path. Raw token counts are the source of truth; estimated_cost_usd
+    is a snapshot at request time so historical rows survive pricing changes.
+    """
+
+    __tablename__ = "token_usage_log"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", name="token_usage_log_pkey"),
+        Index("idx_token_usage_log_created_at", "created_at"),
+        Index("idx_token_usage_log_source", "source"),
+        Index("idx_token_usage_log_request_type", "request_type"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=text("CURRENT_TIMESTAMP")
+    )
+    # High-level feature: "chat", "rfp_extractor", "case_extractor", etc.
+    source: Mapped[str] = mapped_column(String(50))
+    # Finer bucket within a source: chat mode/preset, or extractor step.
+    request_type: Mapped[Optional[str]] = mapped_column(String(64))
+    model: Mapped[Optional[str]] = mapped_column(String(100))
+    input_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    output_tokens: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    cache_creation_input_tokens: Mapped[int] = mapped_column(
+        Integer, server_default=text("0")
+    )
+    cache_read_input_tokens: Mapped[int] = mapped_column(
+        Integer, server_default=text("0")
+    )
+    estimated_cost_usd: Mapped[Optional[float]] = mapped_column(Numeric(12, 6))
+    case_id: Mapped[Optional[int]] = mapped_column(Integer)
+    username: Mapped[Optional[str]] = mapped_column(String(255))
+    conversation_id: Mapped[Optional[str]] = mapped_column(String(64))
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer)
+    meta: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB(none_as_null=True))

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -125,6 +125,7 @@ from services.chat import (
     log_response,
     log_tool_execution,
 )
+from db.token_usage import record_usage
 
 
 # In-memory conversation storage
@@ -499,6 +500,35 @@ DATA:
             total_output_tokens = 0
             total_cache_creation_tokens = 0
             total_cache_read_tokens = 0
+            _usage_start = time.monotonic()
+
+            async def _persist_usage(stop_reason: str) -> None:
+                """Record token usage for this turn. Best-effort, runs off the
+                event loop and after the response is already flushed, so it never
+                delays the user or breaks the stream."""
+                if total_input_tokens == 0 and total_output_tokens == 0:
+                    return
+                await asyncio.to_thread(
+                    record_usage,
+                    source="chat",
+                    request_type=(preset or mode or "full"),
+                    model=selected_model or client.model,
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
+                    cache_creation_input_tokens=total_cache_creation_tokens,
+                    cache_read_input_tokens=total_cache_read_tokens,
+                    case_id=case_context if isinstance(case_context, int) else None,
+                    username=username,
+                    conversation_id=conversation_id,
+                    duration_ms=int((time.monotonic() - _usage_start) * 1000),
+                    meta={
+                        "mode": mode,
+                        "preset": preset,
+                        "tool_count": len(tools) if tools else 0,
+                        "iterations": iteration,
+                        "stop_reason": stop_reason,
+                    },
+                )
 
             # Conversation loop - continue until no more tool calls
             max_iterations = 10
@@ -724,6 +754,7 @@ DATA:
                                     # Send done event
                                     yield f"data: {json.dumps({'type': 'done', 'conversation_id': conversation_id, 'tool_calls': all_tool_calls if all_tool_calls else None, 'model': selected_model or client.model})}\n\n"
                                     await asyncio.sleep(0)  # Flush to client
+                                    await _persist_usage(stop_reason)
                                     return
 
                     except Exception as e:
@@ -760,6 +791,7 @@ DATA:
 
                 yield f"data: {json.dumps({'type': 'done', 'conversation_id': conversation_id, 'tool_calls': all_tool_calls if all_tool_calls else None, 'model': selected_model or client.model})}\n\n"
                 await asyncio.sleep(0)  # Flush to client
+                await _persist_usage("max_iterations")
 
             except Exception as e:
                 _logger.exception(f"Error in SSE generation: {e}")

--- a/services/case_extractor.py
+++ b/services/case_extractor.py
@@ -8,6 +8,8 @@ import os
 from anthropic import Anthropic
 from typing import Optional
 
+from db.token_usage import record_usage_from_message
+
 
 # Tool definition for case info extraction
 EXTRACT_CASE_INFO_TOOL = {
@@ -154,6 +156,10 @@ class CaseExtractor:
                 }
             ]
         )
+        record_usage_from_message(
+            source="case_extractor", request_type="extract_case_info",
+            model=self.model, message=message,
+        )
 
         # Find the tool use block
         for block in message.content:
@@ -273,6 +279,10 @@ Use the submit_document_name tool."""
                 }
             ]
         )
+        record_usage_from_message(
+            source="case_extractor", request_type="improve_document_name",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_document_name":
@@ -324,6 +334,10 @@ Use the submit_filename tool."""
             messages=[
                 {"role": "user", "content": prompt}
             ]
+        )
+        record_usage_from_message(
+            source="case_extractor", request_type="generate_filename",
+            model=self.model, message=message,
         )
 
         for block in message.content:

--- a/services/intake_ai.py
+++ b/services/intake_ai.py
@@ -11,6 +11,7 @@ from datetime import date
 from anthropic import Anthropic
 
 from config import settings
+from db.token_usage import record_usage_from_message
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +126,10 @@ def analyze_intake(intake_data: dict, notes: str = "", comments: list[dict] | No
         max_tokens=1000,
         system=system_prompt,
         messages=[{"role": "user", "content": user_message}],
+    )
+    record_usage_from_message(
+        source="intake_ai", request_type="analyze_intake",
+        model=settings.chat_model_full, message=response,
     )
 
     text = response.content[0].text.strip()

--- a/services/intake_extractor.py
+++ b/services/intake_extractor.py
@@ -9,6 +9,8 @@ import os
 from anthropic import Anthropic
 from typing import Optional
 
+from db.token_usage import record_usage_from_message
+
 
 EXTRACT_INTAKE_INFO_TOOL = {
     "name": "submit_intake_info",
@@ -136,6 +138,10 @@ class IntakeExtractor:
                     "content": f"Extract intake information from this text:\n\n{text}"
                 }
             ]
+        )
+        record_usage_from_message(
+            source="intake_extractor", request_type="extract_intake_info",
+            model=self.model, message=message,
         )
 
         for block in message.content:

--- a/services/interaction_summarizer.py
+++ b/services/interaction_summarizer.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from anthropic import Anthropic
 
+from db.token_usage import record_usage_from_message
+
 
 SYSTEM_PROMPT = """You are a legal assistant summarizing a logged interaction for a personal injury intake.
 
@@ -76,6 +78,10 @@ def summarize_interaction(
         max_tokens=256,
         system=system,
         messages=[{"role": "user", "content": user_msg}],
+    )
+    record_usage_from_message(
+        source="interaction_summarizer", request_type="summarize_interaction",
+        model=settings.extraction_model, message=message,
     )
 
     return message.content[0].text.strip()

--- a/services/invoice_extractor.py
+++ b/services/invoice_extractor.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from anthropic import Anthropic
 
+from db.token_usage import record_usage_from_message
+
 EXTRACT_INVOICE_TOOL = {
     "name": "submit_invoice_info",
     "description": "Submit extracted invoice information from a legal invoice, receipt, or cost document.",
@@ -103,6 +105,10 @@ class InvoiceExtractor:
                 {"role": "user", "content": f"Extract invoice information from this document:\n\n{text}"}
             ],
         )
+        record_usage_from_message(
+            source="invoice_extractor", request_type="extract_from_text",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_invoice_info":
@@ -131,6 +137,10 @@ class InvoiceExtractor:
                 }
             ],
         )
+        record_usage_from_message(
+            source="invoice_extractor", request_type="extract_from_document",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_invoice_info":
@@ -158,6 +168,10 @@ class InvoiceExtractor:
                     ],
                 }
             ],
+        )
+        record_usage_from_message(
+            source="invoice_extractor", request_type="extract_from_image",
+            model=self.model, message=message,
         )
 
         for block in message.content:

--- a/services/rfp_extractor.py
+++ b/services/rfp_extractor.py
@@ -12,6 +12,8 @@ import logging
 from typing import Optional
 from anthropic import Anthropic
 
+from db.token_usage import record_usage_from_message
+
 _logger = logging.getLogger("services.rfp_extractor")
 
 
@@ -183,6 +185,10 @@ IMPORTANT: Also generate a response_document_title — this is the title for the
             ]
         )
         _log_usage("extract_info", message)
+        record_usage_from_message(
+            source="rfp_extractor", request_type="extract_info",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_rfp_info":
@@ -217,6 +223,10 @@ Extract ALL requests found in the document.""",
             ]
         )
         _log_usage("extract_requests", message)
+        record_usage_from_message(
+            source="rfp_extractor", request_type="extract_requests",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_rfp_requests":
@@ -263,6 +273,10 @@ Be judicious — only suggest objections that are genuinely applicable. Most req
             ]
         )
         _log_usage("analyze", message)
+        record_usage_from_message(
+            source="rfp_extractor", request_type="analyze",
+            model=self.model, message=message,
+        )
 
         for block in message.content:
             if block.type == "tool_use" and block.name == "submit_analysis":

--- a/services/toa_extractor.py
+++ b/services/toa_extractor.py
@@ -15,6 +15,7 @@ from anthropic import Anthropic
 from pypdf import PdfReader
 
 from config import settings
+from db.token_usage import record_usage_from_message
 
 _logger = logging.getLogger("services.toa_extractor")
 
@@ -193,6 +194,10 @@ def extract_authorities(file_bytes: bytes) -> dict:
         system=_SYSTEM_PROMPT,
         messages=[{"role": "user", "content": user_message}],
     )
+    record_usage_from_message(
+        source="toa_extractor", request_type="extract_citations",
+        model=model, message=response,
+    )
 
     # Step 3: Parse JSON response
     response_text = ""
@@ -226,6 +231,10 @@ def extract_authorities(file_bytes: bytes) -> dict:
                     ),
                 },
             ],
+        )
+        record_usage_from_message(
+            source="toa_extractor", request_type="extract_citations_retry",
+            model=model, message=retry_response,
         )
         retry_text = ""
         for block in retry_response.content:


### PR DESCRIPTION
Persist one row per Claude request to a new token_usage_log table so we can analyze cost per request type in production. Writes are best-effort and off the request critical path (chat logs after the response is flushed, via a thread) so logging can never slow down or break a request.

Covers the chat stream (bucketed by mode/preset) and all extractor services (case, RFP, invoice, TOA, intake, interaction summarizer). Stores raw token counts plus a cost snapshot computed from a per-model pricing map, so historical rows survive future pricing changes.