### PR TITLE
Fix timezone handling for date comparisons across frontend and backend

### DIFF
--- a/db/cases.py
+++ b/db/cases.py
@@ -20,6 +20,7 @@ from models import (
     Case, User, PersonRole, Role, Person, Event, Task,
     Proceeding, ProceedingJudge, Judge, Jurisdiction,
 )
+from lib.tz import today_la_sql
 
 
 def _add_months(d: datetime.date, months: int) -> datetime.date:
@@ -151,7 +152,7 @@ def get_all_cases(status_filter: Optional[str] = None, limit: int = None,
 
         upcoming_event_sq = literal_column("""(
             SELECT COUNT(*) FROM events e
-            WHERE e.case_id = cases.id AND e.date >= CURRENT_DATE
+            WHERE e.case_id = cases.id AND e.date >= (now() AT TIME ZONE 'America/Los_Angeles')::date
         )""").label("upcoming_event_count")
 
         stmt = (
@@ -617,7 +618,7 @@ def get_case_summary(case_id: int) -> Optional[dict]:
             SELECT COUNT(*) FROM events e WHERE e.case_id = cases.id
         )""").label("event_count")
         upcoming_event_sq = literal_column("""(
-            SELECT COUNT(*) FROM events e WHERE e.case_id = cases.id AND e.date >= CURRENT_DATE
+            SELECT COUNT(*) FROM events e WHERE e.case_id = cases.id AND e.date >= (now() AT TIME ZONE 'America/Los_Angeles')::date
         )""").label("upcoming_event_count")
         note_count_sq = literal_column("""(
             SELECT COUNT(*) FROM notes n WHERE n.case_id = cases.id
@@ -676,8 +677,8 @@ def get_dashboard_stats(attorney_ids: list[int] | None = None) -> dict:
         upcoming_events = session.scalar(
             select(func.count()).select_from(Event)
             .where(
-                Event.date >= func.current_date(),
-                Event.date <= func.current_date() + 30,
+                Event.date >= today_la_sql(),
+                Event.date <= today_la_sql() + 30,
             )
         )
 

--- a/db/events.py
+++ b/db/events.py
@@ -18,6 +18,7 @@ from .feature_gates import (
 )
 from models import Event, Case, Task, User
 from schemas import EventOut
+from lib.tz import today_la_sql
 
 
 def _serialize_value(val):
@@ -86,7 +87,7 @@ def get_upcoming_events(limit: int = None, offset: int = None, include_past: boo
                         past_days: int = 14, case_id: int = None, user_id: int = None,
                         attendee_id: int = None) -> dict:
     """Get events (hearings, depositions, filing deadlines, etc.)."""
-    today = func.current_date()
+    today = today_la_sql()
 
     # Task count subquery
     task_count_sq = (
@@ -362,7 +363,7 @@ def search_events(query: str = None, case_id: int = None,
 def get_calendar(days: int = 30, include_tasks: bool = True,
                  include_events: bool = True) -> List[dict]:
     """Get calendar items for the next N days."""
-    today = func.current_date()
+    today = today_la_sql()
     items = []
 
     with SessionLocal() as session:

--- a/db/tasks.py
+++ b/db/tasks.py
@@ -20,6 +20,7 @@ from .feature_gates import (
 )
 from models import Task, Case, Event, User, Intake
 from schemas import TaskOut, UserBriefOut, TaskDetailOut
+from lib.tz import today_la_sql
 
 
 def _task_to_dict(task: Task) -> dict:
@@ -370,7 +371,7 @@ def reschedule_overdue_tasks(new_date: str, task_ids: List[int] = None) -> dict:
     with SessionLocal() as session:
         stmt = (
             update(Task)
-            .where(Task.due_date < func.current_date(), Task.status != "Done")
+            .where(Task.due_date < today_la_sql(), Task.status != "Done")
             .where(feature_enabled_filter(FEATURE_TASKS, Task.case_id))
             .values(due_date=new_date)
         )

--- a/db/trial_calendar.py
+++ b/db/trial_calendar.py
@@ -5,6 +5,7 @@ from sqlalchemy import select, literal_column
 
 from models import Case, Event
 from .session import SessionLocal
+from lib.tz import today_la
 
 
 def _add_months(d: datetime.date, months: int) -> datetime.date:
@@ -19,7 +20,7 @@ def _add_months(d: datetime.date, months: int) -> datetime.date:
 
 def get_trial_calendar(months_ahead: int = 6, months_behind: int = 1) -> dict:
     """Get trial calendar data: trials and blocking events within a date range."""
-    today = datetime.date.today()
+    today = today_la()
     range_start = _add_months(today, -months_behind) if months_behind > 0 else today
     range_end = _add_months(today, months_ahead)
 
@@ -183,7 +184,7 @@ def find_available_trial_slots(
     max_results: int = 10,
 ) -> dict:
     """Find available weekday blocks for a trial of the given duration."""
-    today = datetime.date.today()
+    today = today_la()
     range_start = (
         max(datetime.date.fromisoformat(earliest_date), today + datetime.timedelta(days=1))
         if earliest_date

--- a/frontend/src/components/common/trial-edit-popover.tsx
+++ b/frontend/src/components/common/trial-edit-popover.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { PencilEdit01Icon, InformationCircleIcon, Add01Icon } from "@hugeicons/core-free-icons"
+import { todayInLA } from "@/lib/datetime"
 import { updateCase } from "@/services/cases"
 import {
   Popover,
@@ -33,8 +34,7 @@ export function formatTrialDate(dateStr: string | null): string {
 export function daysUntil(dateStr: string | null): number | null {
   if (!dateStr) return null
   const d = new Date(dateStr + "T00:00:00")
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
+  const now = todayInLA()
   return Math.ceil((d.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
 }
 

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -55,6 +55,22 @@ export function formatDateHeader(iso: string): string {
   })
 }
 
+// Current date in America/Los_Angeles as a local Date at midnight. Pair with
+// parseLocalDate (which builds local Dates from YYYY-MM-DD) for day-bucket
+// comparisons — never use `new Date()` directly, which keys off browser tz.
+export function todayInLA(): Date {
+  const [y, m, d] = new Intl.DateTimeFormat("en-CA", {
+    timeZone: LA,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+    .format(new Date())
+    .split("-")
+    .map(Number)
+  return new Date(y, m - 1, d)
+}
+
 export function getDateKey(iso: string): string {
   return new Intl.DateTimeFormat("en-CA", {
     timeZone: LA,

--- a/frontend/src/pages/cases/columns.tsx
+++ b/frontend/src/pages/cases/columns.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { EyeIcon } from "@hugeicons/core-free-icons"
 import type { CaseListItem } from "@/types/case"
 import { DataTableColumnHeader } from "@/components/common/data-table-column-header"
+import { todayInLA } from "@/lib/datetime"
 import { StatusSelectCell } from "@/pages/cases/components/status-select-cell"
 import { TrialEditCell } from "@/components/common/trial-edit-popover"
 import { getAvatarStyleById } from "@/lib/badge-colors"
@@ -23,8 +24,7 @@ function formatDate(dateStr: string | null): string {
 function daysUntil(dateStr: string | null): number | null {
   if (!dateStr) return null
   const d = new Date(dateStr + "T00:00:00")
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
+  const now = todayInLA()
   return Math.ceil((d.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
 }
 

--- a/frontend/src/pages/cases/components/case-events-card.tsx
+++ b/frontend/src/pages/cases/components/case-events-card.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
+import { todayInLA } from "@/lib/datetime"
 import {
   Add01Icon,
   Search01Icon,
@@ -58,8 +59,7 @@ export function CaseEventsCard({ caseId, onAdd, onAiAdd }: CaseEventsCardProps) 
     const upcoming = data?.events ?? []
     const all = allData?.events ?? []
 
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
+    const today = todayInLA()
     const starredPast = all.filter((e) => {
       if (!e.starred) return false
       const eventDate = new Date(`${e.date}T00:00:00`)

--- a/frontend/src/pages/cases/components/case-key-dates.tsx
+++ b/frontend/src/pages/cases/components/case-key-dates.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { AlertCircleIcon, Calendar03Icon, StarIcon } from "@hugeicons/core-free-icons"
+import { todayInLA } from "@/lib/datetime"
 import type { CaseDetail, CaseStatus } from "@/types/case"
 import { updateCase } from "@/services/cases"
 import { getEvents } from "@/services/events"
@@ -35,8 +36,7 @@ type DateUrgency = "overdue" | "imminent" | "approaching" | "normal" | "none"
 
 function getDateUrgency(dateStr: string | null): DateUrgency {
   if (!dateStr) return "none"
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayInLA()
   const target = new Date(`${dateStr}T00:00:00`)
   const diffMs = target.getTime() - today.getTime()
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
@@ -48,8 +48,7 @@ function getDateUrgency(dateStr: string | null): DateUrgency {
 }
 
 function getDaysLabel(dateStr: string): string {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayInLA()
   const target = new Date(`${dateStr}T00:00:00`)
   const diffMs = target.getTime() - today.getTime()
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))

--- a/frontend/src/pages/events/components/event-list-item.tsx
+++ b/frontend/src/pages/events/components/event-list-item.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 import { getBadgeStyle, getAvatarStyleById } from "@/lib/badge-colors"
+import { todayInLA } from "@/lib/datetime"
 
 function parseLocalDate(dateStr: string): Date {
   const [y, m, d] = dateStr.split("-").map(Number)
@@ -32,8 +33,7 @@ function parseLocalDate(dateStr: string): Date {
 
 function formatDate(dateStr: string): string {
   const d = parseLocalDate(dateStr)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayInLA()
   const tomorrow = new Date(today)
   tomorrow.setDate(tomorrow.getDate() + 1)
 
@@ -212,11 +212,7 @@ export function EventListItem({
   onRemoveAttendee,
   hideCaseBadge,
 }: EventListItemProps) {
-  const isPast = parseLocalDate(event.date) < (() => {
-    const d = new Date()
-    d.setHours(0, 0, 0, 0)
-    return d
-  })()
+  const isPast = parseLocalDate(event.date) < todayInLA()
 
   return (
     <div

--- a/frontend/src/pages/events/components/event-list-view.tsx
+++ b/frontend/src/pages/events/components/event-list-view.tsx
@@ -18,6 +18,7 @@ import { EventPinnedItem } from "@/pages/events/components/event-pinned-item"
 import { EventDetailDialog } from "@/pages/events/components/event-detail-dialog"
 import { groupEvents, type EventGroupBy } from "@/pages/events/group-events"
 import { getBadgeStyle } from "@/lib/badge-colors"
+import { todayInLA } from "@/lib/datetime"
 
 function parseLocalDate(dateStr: string): Date {
   const [y, m, d] = dateStr.split("-").map(Number)
@@ -75,8 +76,7 @@ export function EventListView({
 
   const { pinnedEvents, groupedEvents } = useMemo(() => {
     if (showPast) return { pinnedEvents: [], groupedEvents: events }
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
+    const today = todayInLA()
     const pinned: EventListItemType[] = []
     const rest: EventListItemType[] = []
     for (const e of events) {

--- a/frontend/src/pages/events/group-events.ts
+++ b/frontend/src/pages/events/group-events.ts
@@ -1,4 +1,5 @@
 import type { EventListItem } from "@/types/event"
+import { todayInLA } from "@/lib/datetime"
 
 export type EventGroupBy = "date" | "case"
 
@@ -8,12 +9,6 @@ export interface EventGroup {
   events: EventListItem[]
   sortOrder: number
   caseColor?: string | null
-}
-
-function todayMidnight(): Date {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
 }
 
 function parseLocalDate(dateStr: string): Date {
@@ -48,7 +43,7 @@ const sortByDateDesc = (a: EventListItem, b: EventListItem) => {
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 export function groupEventsByDate(events: EventListItem[]): EventGroup[] {
-  const today = todayMidnight()
+  const today = todayInLA()
   const tomorrow = new Date(today)
   tomorrow.setDate(tomorrow.getDate() + 1)
   const dayAfterTomorrow = new Date(tomorrow)
@@ -164,7 +159,7 @@ export function groupEventsByCase(events: EventListItem[]): EventGroup[] {
 }
 
 export function groupPastEventsByDate(events: EventListItem[]): EventGroup[] {
-  const today = todayMidnight()
+  const today = todayInLA()
   const yesterday = new Date(today)
   yesterday.setDate(yesterday.getDate() - 1)
 

--- a/frontend/src/pages/intakes/columns.tsx
+++ b/frontend/src/pages/intakes/columns.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { SparklesIcon } from "@hugeicons/core-free-icons"
+import { todayInLA } from "@/lib/datetime"
 import type { Intake } from "@/types/intake"
 import { formatTimestampRaw } from "@/lib/datetime"
 import { DataTableColumnHeader } from "@/components/common/data-table-column-header"
@@ -106,8 +107,7 @@ function daysUntil(doi: string, months: number): number {
   const d = parseLocalDate(doi)
   const deadline = new Date(d)
   deadline.setMonth(deadline.getMonth() + months)
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
+  const now = todayInLA()
   return Math.ceil((deadline.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
 }
 

--- a/frontend/src/pages/intakes/components/intake-metadata.tsx
+++ b/frontend/src/pages/intakes/components/intake-metadata.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import type { Intake } from "@/types/intake"
 import { formatPhone } from "@/lib/utils"
+import { todayInLA } from "@/lib/datetime"
 import { updateIntake } from "@/services/intakes"
 import { Input } from "@/components/ui/input"
 import { DatePicker } from "@/components/ui/date-picker"
@@ -48,8 +49,7 @@ function formatDate(dateStr: string | null): string {
 function daysUntil(doi: string, months: number): number {
   const deadline = parseLocalDate(doi)
   deadline.setMonth(deadline.getMonth() + months)
-  const now = new Date()
-  now.setHours(0, 0, 0, 0)
+  const now = todayInLA()
   return Math.ceil((deadline.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
 }
 

--- a/frontend/src/pages/tasks/columns.tsx
+++ b/frontend/src/pages/tasks/columns.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 import { statuses, urgencies } from "@/pages/tasks/task-data"
+import { todayInLA } from "@/lib/datetime"
 
 function parseLocalDate(dateStr: string): Date {
   const [y, m, d] = dateStr.split("-").map(Number)
@@ -126,10 +127,8 @@ export function getColumns(options: {
       cell: ({ row }) => {
         const dateStr = row.getValue("due_date") as string | null
         if (!dateStr) return <span className="text-muted-foreground">—</span>
-        const today = new Date()
-        today.setHours(0, 0, 0, 0)
         const isOverdue =
-          parseLocalDate(dateStr) < today && row.original.status !== "Done"
+          parseLocalDate(dateStr) < todayInLA() && row.original.status !== "Done"
         return (
           <span className={cn(isOverdue && "text-destructive font-medium")}>
             {formatDate(dateStr)}

--- a/frontend/src/pages/tasks/components/task-list-item.tsx
+++ b/frontend/src/pages/tasks/components/task-list-item.tsx
@@ -41,6 +41,7 @@ import {
 import { cn } from "@/lib/utils"
 import { getBadgeStyle, getAvatarStyleById } from "@/lib/badge-colors"
 import { statuses, urgencies } from "@/pages/tasks/task-data"
+import { todayInLA } from "@/lib/datetime"
 
 function parseLocalDate(dateStr: string): Date {
   const [y, m, d] = dateStr.split("-").map(Number)
@@ -49,8 +50,7 @@ function parseLocalDate(dateStr: string): Date {
 
 function formatDate(dateStr: string): string {
   const d = parseLocalDate(dateStr)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayInLA()
   const tomorrow = new Date(today)
   tomorrow.setDate(tomorrow.getDate() + 1)
 
@@ -253,9 +253,7 @@ interface TaskListItemProps {
 
 function isOverdue(dateStr: string | null): boolean {
   if (!dateStr) return false
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  return parseLocalDate(dateStr) < today
+  return parseLocalDate(dateStr) < todayInLA()
 }
 
 function InlineEventLinker({
@@ -371,8 +369,7 @@ function formatCompletionDate(task: TaskListItemType): string {
   const dateStr = task.completion_date
   if (!dateStr) return "Completed"
   const d = parseLocalDate(dateStr)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = todayInLA()
   const yesterday = new Date(today)
   yesterday.setDate(yesterday.getDate() - 1)
 

--- a/frontend/src/pages/tasks/group-tasks.ts
+++ b/frontend/src/pages/tasks/group-tasks.ts
@@ -1,4 +1,5 @@
 import type { TaskListItem } from "@/types/task"
+import { todayInLA } from "@/lib/datetime"
 
 export type TaskGroupBy = "date" | "case"
 
@@ -8,12 +9,6 @@ export interface TaskGroup {
   tasks: TaskListItem[]
   sortOrder: number
   caseColor?: string | null
-}
-
-function todayMidnight(): Date {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
 }
 
 function parseLocalDate(dateStr: string): Date {
@@ -33,7 +28,7 @@ function endOfWeek(date: Date): Date {
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 export function groupTasksByDate(tasks: TaskListItem[]): TaskGroup[] {
-  const today = todayMidnight()
+  const today = todayInLA()
   const tomorrow = new Date(today)
   tomorrow.setDate(tomorrow.getDate() + 1)
   const dayAfterTomorrow = new Date(tomorrow)
@@ -188,7 +183,7 @@ const sortByCompletionDesc = (a: TaskListItem, b: TaskListItem) => {
 }
 
 export function groupDoneTasksByDate(tasks: TaskListItem[]): TaskGroup[] {
-  const today = todayMidnight()
+  const today = todayInLA()
   const yesterday = new Date(today)
   yesterday.setDate(yesterday.getDate() - 1)
 

--- a/lib/tz.py
+++ b/lib/tz.py
@@ -1,5 +1,7 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
+
+from sqlalchemy import Date, cast, func
 
 UTC = timezone.utc
 LA = ZoneInfo("America/Los_Angeles")
@@ -7,3 +9,19 @@ LA = ZoneInfo("America/Los_Angeles")
 
 def utc_now() -> datetime:
     return datetime.now(UTC)
+
+
+def today_la() -> date:
+    """Current calendar date in America/Los_Angeles."""
+    return datetime.now(LA).date()
+
+
+def today_la_sql():
+    """SQLAlchemy expression for the current date in America/Los_Angeles.
+
+    Use instead of func.current_date(): current_date resolves in the database's
+    timezone (UTC in production), so in the evening Pacific it has already
+    rolled over to the next calendar day, which silently drops same-day events
+    and tasks from "today" filters.
+    """
+    return cast(func.timezone("America/Los_Angeles", func.now()), Date)


### PR DESCRIPTION
## Summary
This PR fixes a critical timezone bug where date comparisons were using the browser's local timezone instead of America/Los_Angeles (Pacific), causing events and tasks to appear on the wrong day in the evening. The fix centralizes timezone handling by introducing `todayInLA()` on the frontend and `today_la_sql()` on the backend, ensuring all date-based filtering uses Pacific time consistently.

## Key Changes

**Backend (`lib/tz.py`)**
- Added `today_la()` function to get the current calendar date in Pacific timezone
- Added `today_la_sql()` SQLAlchemy expression for use in database queries, which converts `now()` to Pacific timezone before casting to `Date`
- This prevents the database from using UTC's `CURRENT_DATE`, which rolls over to the next day hours before Pacific time does

**Backend Database Queries**
- Updated `db/cases.py`: Replaced `CURRENT_DATE` with `today_la_sql()` in upcoming event count subqueries
- Updated `db/events.py`: Replaced `func.current_date()` with `today_la_sql()` in `get_upcoming_events()` and `get_calendar()`
- Updated `db/tasks.py`: Replaced `func.current_date()` with `today_la_sql()` in `reschedule_overdue_tasks()`
- Updated `db/trial_calendar.py`: Replaced `datetime.date.today()` with `today_la()` for trial calendar date range calculations

**Frontend (`lib/datetime.ts`)**
- Added `todayInLA()` function that uses `Intl.DateTimeFormat` with explicit `timeZone: "America/Los_Angeles"` to get the current date as a local midnight Date object
- This replaces all ad-hoc `new Date()` + `setHours(0,0,0,0)` patterns which relied on browser timezone

**Frontend Components**
- Removed duplicate `todayMidnight()` functions from `group-events.ts` and `group-tasks.ts`, replaced with imports of `todayInLA()`
- Updated all date comparison logic in:
  - `event-list-item.tsx`: `formatDate()` and `isPast` check
  - `task-list-item.tsx`: `formatDate()`, `isOverdue()`, and `formatCompletionDate()`
  - `columns.tsx` (tasks): Overdue status calculation
  - `columns.tsx` (cases): `daysUntil()` calculation
  - `case-key-dates.tsx`: `getDateUrgency()` and `getDaysLabel()`
  - `case-events-card.tsx`: Starred past events filtering
  - `event-list-view.tsx`: Pinned events separation
  - `trial-edit-popover.tsx`: `daysUntil()` calculation
  - `intake-metadata.tsx` and `intake-columns.tsx`: Deadline calculations

## Implementation Details

- All date-only fields (event dates, task due dates, DOI, trial dates) are stored as `Date` columns in the database and transmitted as `YYYY-MM-DD` strings
- The fix ensures that when comparing these dates to "today", both sides use Pacific timezone
- Frontend uses `parseLocalDate()` helper (already present) to convert `YYYY-MM-DD` strings to local midnight Date objects
- Backend uses SQLAlchemy's `func.timezone()` to shift `now()` to Pacific before casting to `Date`
- This follows the timezone conventions documented in CLAUDE.md: database stores UTC, but date-only comparisons use Pacific time

https://claude.ai/code/session_012bTVV3PPZzh6TaVKwksjaA