### PR TITLE
feat(trial-calendar): strike out settled/closed cases and use short name on mobile

### DIFF
--- a/frontend/src/pages/trial-calendar/components/trial-columns.tsx
+++ b/frontend/src/pages/trial-calendar/components/trial-columns.tsx
@@ -11,6 +11,7 @@ import { DataTableColumnHeader } from "@/components/common/data-table-column-hea
 import { getAvatarStyleById } from "@/lib/badge-colors"
 import { getEventTypeLabel, getEventTypeColor } from "@/lib/event-types"
 import { TrialEditCell } from "@/components/common/trial-edit-popover"
+import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
   Tooltip,
@@ -28,7 +29,7 @@ function parseDate(s: string): Date {
   return new Date(y, m - 1, d)
 }
 
-const STALE_STATUSES = new Set(["Settl. Pend.", "Closed"])
+export const STALE_STATUSES = new Set(["Settl. Pend.", "Closed"])
 
 /** Read-only hold date with a Confirm action (promotes it to the trial date). */
 function HoldConfirmCell({ caseId, date }: { caseId: number; date: string }) {
@@ -105,19 +106,20 @@ export function getTrialColumns(options: {
           const isStale = STALE_STATUSES.has(status)
           const displayName = options.isMobile && short_name ? short_name : case_name
           const truncated = displayName.length > 35 ? `${displayName.slice(0, 35)}…` : displayName
+          const nameClass = cn("font-medium", isStale && "line-through text-muted-foreground")
           return (
             <div className="flex items-center gap-2">
               {displayName.length > 35 ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="font-medium">{truncated}</span>
+                    <span className={nameClass}>{truncated}</span>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-md text-xs">
                     {case_name}
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <span className="font-medium">{displayName}</span>
+                <span className={nameClass}>{displayName}</span>
               )}
               {proposed && (
                 <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 bg-warning text-warning-foreground whitespace-nowrap">

--- a/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
+++ b/frontend/src/pages/trial-calendar/components/trial-list-mobile.tsx
@@ -5,7 +5,9 @@ import type { TrialItem, BlockingEvent } from "@/services/trial-calendar"
 import type { StaffMember } from "@/services/staff"
 import { getAvatarStyleById } from "@/lib/badge-colors"
 import { getEventTypeLabel, getEventTypeColor } from "@/lib/event-types"
+import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
+import { STALE_STATUSES } from "./trial-columns"
 
 type Row =
   | { kind: "trial"; date: string; trial: TrialItem }
@@ -48,6 +50,7 @@ export function TrialListMobile({
       {rows.map((row) => {
         if (row.kind === "trial") {
           const t = row.trial
+          const isStale = STALE_STATUSES.has(t.status)
           return (
             <button
               key={`trial-${t.case_id}`}
@@ -73,7 +76,14 @@ export function TrialListMobile({
                   })}
                 </div>
               )}
-              <span className="min-w-0 flex-1 truncate font-medium">{t.case_name}</span>
+              <span
+                className={cn(
+                  "min-w-0 flex-1 truncate font-medium",
+                  isStale && "line-through text-muted-foreground",
+                )}
+              >
+                {t.short_name ?? t.case_name}
+              </span>
               <span className="shrink-0 text-sm tabular-nums">
                 {format(parseDate(t.trial_date), "MMM d, yyyy")}
               </span>


### PR DESCRIPTION
Cross out the case name on both desktop and mobile when a trial's case is
settlement-pending or closed, so it's clear the case is still on the calendar
but not going forward. Mobile now uses the case short name and omits the
status pill (no room); desktop keeps the existing status pill.

https://claude.ai/code/session_01EDSasdWMhMigWh9d7zi9qe