### PR TITLE
Plan: voice-driven work log (case + contact activity logging)

### DIFF
--- a/docs/plans/worklog-feature-plan.md
+++ b/docs/plans/worklog-feature-plan.md
@@ -1,0 +1,493 @@
+# Implementation Plan — Work Log (Voice-Driven Activity Logging)
+
+> **Status:** Ready to implement. This plan was developed against the current
+> codebase (branch `claude/voice-log-case-contact-Qgp6Y`) with all file paths,
+> patterns, and the current Alembic head verified. Hand this to a local Claude
+> session that has the database, Python deps, and dev servers available.
+
+---
+
+## 1. The Feature (what we're building and why)
+
+The user (an attorney) wants to record a short, **stream-of-consciousness voice/text
+memo once or twice a day** describing what they worked on — e.g. *"I spent the
+morning on the opposition to the motion to dismiss in the Armstrong case, then had
+a call with Tanner Navaroli about the Reyes matter, then drafted discovery for
+Armstrong again."*
+
+The system turns that unstructured dump into discrete, time-estimated **work log
+entries**, each linked to a case (and optionally to people), so that later the user
+can:
+
+- Open a **case** and see everything they did on it, by day, with a rough time total.
+- Open a **contact** and see every time they interacted with that person.
+
+### Design philosophy (important — these shape every decision)
+
+- **This is NOT a time tracker.** No start/stop, no 10:00–11:00 precision. The goal
+  is *broad strokes* — a habit of recording work so the user gets a rough sense of
+  effort per case over time.
+- **No nitpicky follow-up questions.** If the user doesn't say how long something
+  took, the system **estimates** using sensible defaults. It never interrogates.
+- **Estimates from context.** "Had a call" → default ~30 min. "Spent the morning on
+  X" with nothing else competing for the morning → ~3.5–4 hrs. The model reasons
+  about the *whole day as a budget*.
+
+---
+
+## 2. Design Decisions (already resolved with the user — do not re-litigate)
+
+| Decision | Resolution |
+|---|---|
+| Fan-out | **One memo → many activities.** A single dump splits into N entries. |
+| Activity ↔ case | **Each activity belongs to exactly one case** (or none → unmatched). |
+| Time granularity | **Per-activity** `minutes` estimate. Each entry gets its own duration. |
+| Activity ↔ people | **Many-to-many.** One activity (e.g. a meeting) can name several people. |
+| Unknown names | **Preserve raw text, leave unlinked.** Never drop the original phrase. If a case/person isn't found, save the entry with `case_id = NULL` and keep `raw_reference`. |
+| Review step | **One-glance, editable, non-blocking.** After parsing, show the parsed entries as an editable list; user can fix a mislinked case/person or nudge minutes, then Save. Nothing persists until confirmed. This is NOT the "nitpicky questions" the user dislikes — it's a single confirmation screen. |
+| Audio | **Do NOT store audio.** Text only. For the MVP the user dictates with their phone's native dictation (or pastes) into a textarea. Transcription/audio capture is explicitly out of scope. |
+| Time estimation | **Two-pass within a single LLM call:** (1) split the memo into discrete activities, (2) divide the day's time across them so "the morning" can't be double-counted. |
+| Entry point | **Dedicated `/log` page + a global button in the app header.** Logging spans multiple cases, so it cannot live on a single case page. |
+| Naming | Use the domain name **`worklog`** internally. **Do NOT use `activity`** — that namespace is already taken (see §3). User-facing copy can say "Work Log" / "Activities". |
+
+---
+
+## 3. Critical Codebase Facts (verified — saves you rediscovery)
+
+### Naming collision to avoid
+`routes/activity.py` + `db/activity.py` + `register_activity_routes` already exist and
+implement **page-view analytics** (`POST /api/v1/tracking/pageview`,
+`GET /api/v1/activity/summary`, etc.). The frontend `CaseActivityFeed` is a
+**comment/system-event feed** backed by `case_comments`, not work logging. **Keep the
+new feature in a separate `worklog` namespace** to avoid colliding with both.
+
+### Current Alembic head
+- **Head revision: `d2cd156b344a`** (file
+  `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`). Single head, verified.
+- Your new migration's `down_revision` must be `'d2cd156b344a'` — **unless** you use
+  `alembic revision --autogenerate` (preferred, since you have a live DB), which sets
+  it automatically. Re-verify the head at implementation time with `alembic heads`.
+
+### Patterns to mirror (exact reference files)
+- **Migration format:** `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`
+- **DB module:** `db/notes.py` — `SessionLocal()` context manager, `_x_to_dict()`
+  helper using the Pydantic Out schema, `flush()/refresh()/commit()` ordering.
+- **DB exports:** `db/__init__.py` — import block (~line 168 for notes) + `__all__`
+  list (~line 524). Add your new functions to both.
+- **Routes:** `routes/notes.py` — `@mcp.custom_route(...)`, `auth.require_auth(request)`,
+  `asyncio.to_thread(db.fn, ...)`, `pydantic_error(e)` / `api_error(...)` from `.common`.
+- **Route registration:** `routes/__init__.py` — import (~lines 35–66), call
+  `register_worklog_routes(mcp)` **before** `register_static_routes(mcp)` (currently
+  line 152), and add to `__all__` (~line 156). **Static must stay last** (SPA catch-all).
+- **Input schemas:** `schemas/inputs.py` — plain `BaseModel`s, no `__all__` (picked up by
+  `from .inputs import *` in `schemas/__init__.py`). Note pattern at lines 113–119.
+- **Output schemas:** `schemas/outputs.py` — `model_config = ConfigDict(from_attributes=True)`;
+  `model_dump(mode="json")` auto-ISO-formats datetimes. `NoteOut` at lines 97–110,
+  `PersonOut` at 357–369 are good templates.
+- **LLM extraction:** `services/case_extractor.py` — sync `anthropic.Anthropic` client,
+  `tool_choice={"type": "tool", "name": "..."}` to FORCE structured output, read
+  `block.input` from the `tool_use` block, and
+  `db.token_usage.record_usage_from_message(source=..., request_type=..., model=..., message=...)`.
+  Model comes from `settings.extraction_model` (`config.py`), API key from
+  `os.environ["ANTHROPIC_API_KEY"]`.
+- **MCP tool:** `tools.py` `manage_note` (~line 1292) — `@mcp.tool()`, helpers
+  `validation_error()`, `error_response()`, `not_found_error()`; `Context` carries
+  `case_context` for the currently-viewed case. Registered inside `register_tools(mcp)`.
+- **MCP instructions:** `main.py` `MCP_INSTRUCTIONS` string (~lines 26–69; tools overview
+  ~30–41). **Hand-maintained** — must be updated when adding an MCP tool.
+
+### Frontend facts
+- **Case detail page:** `frontend/src/pages/cases/detail.tsx` — renders
+  `<CaseNotesPanel .../>` and `<CaseActivityFeed caseId={caseData.id} />` in a right
+  column (~line 315). Add the new Work Log card here.
+- **Activity feed component (pattern reference):**
+  `frontend/src/pages/cases/components/case-activity-feed.tsx` — TanStack Query
+  (`useQuery`), service call, card layout.
+- **Contact detail dialog:** `frontend/src/components/common/contact-detail-dialog.tsx` —
+  sections for contact info, an SMS section, and roles-by-case. Add an "Interactions"
+  (work-log) section here.
+- **Service pattern:** `frontend/src/services/cases.ts` — `apiFetch` from `@/lib/api`,
+  `URLSearchParams`, `res.ok` checks. **Types** in `frontend/src/types/case.ts`.
+- **Feature toggles:** `case.feature_toggles` (JSONB) gated via `isCaseFeatureEnabled(...)`.
+  Decide whether the case Work Log card is always-on or toggle-gated (recommendation:
+  **always-on**, since logging is global, not a per-case opt-in section).
+- **Conventions (from CLAUDE.md):** `@/` import alias always; `kebab-case.tsx` files;
+  **square corners** (no `rounded-*`); semantic color tokens (`--success`, etc.);
+  **Hugeicons** (not Lucide); TanStack Query for server state; React Hook Form + Zod for
+  forms; shadcn primitives via `npx shadcn@latest add`. Use the shadcn MCP to check
+  component APIs before writing UI.
+- **To locate at implementation time** (not verified here): the **router** (React Router
+  v7 route table — likely `frontend/src/App.tsx` or a `routes`/`router` file) and the
+  **app header/sidebar** (`frontend/src/components/layout/` per CLAUDE.md, e.g.
+  `app-sidebar.tsx` / a header component). Add the `/log` route and the global nav button
+  there.
+
+---
+
+## 4. Data Model
+
+Three new tables. **Preferred workflow:** add the SQLAlchemy models to `models.py`, then
+run `alembic revision --autogenerate -m "add worklog tables"`, review, and
+`alembic upgrade head`. (`models.py` is the schema source of truth.)
+
+### `voice_logs` — one row per brain-dump
+| column | type | notes |
+|---|---|---|
+| `id` | Integer PK | |
+| `transcript` | Text, not null | the raw text the user typed/dictated |
+| `log_date` | Date, not null | the date the work happened (defaults to today, editable in UI) |
+| `created_by` | Integer FK → `users.id` ON DELETE SET NULL, nullable | who logged it |
+| `created_at` | DateTime(timezone=True), server_default CURRENT_TIMESTAMP | |
+
+### `worklog_entries` — the split-out, time-estimated activities
+| column | type | notes |
+|---|---|---|
+| `id` | Integer PK | |
+| `voice_log_id` | Integer FK → `voice_logs.id` ON DELETE CASCADE, not null | |
+| `case_id` | Integer FK → `cases.id` ON DELETE SET NULL, **nullable** | NULL = unmatched |
+| `minutes` | Integer, not null | estimated duration |
+| `description` | Text, not null | concise summary of the work |
+| `raw_reference` | Text, nullable | the original phrase from the memo (always preserved, esp. when unmatched) |
+| `activity_date` | Date, not null | denormalized from the voice_log's `log_date` for easy per-case/day queries |
+| `created_at` | DateTime(timezone=True), server_default CURRENT_TIMESTAMP | |
+
+Indexes: `case_id`, `voice_log_id`, `activity_date`.
+
+### `worklog_entry_people` — junction (entry ↔ persons, many-to-many)
+| column | type | notes |
+|---|---|---|
+| `entry_id` | Integer FK → `worklog_entries.id` ON DELETE CASCADE | composite PK |
+| `person_id` | Integer FK → `persons.id` ON DELETE CASCADE | composite PK |
+
+Index: `person_id` (for the "click a contact → see interactions" query).
+
+**SQLAlchemy notes:** follow the `models.py` conventions exactly —
+`Mapped[...]`/`mapped_column`, `DateTime(timezone=True)` for all timestamps (UTC),
+`server_default=text("CURRENT_TIMESTAMP")`, explicit `ForeignKeyConstraint` +
+`Index` in `__table_args__`, and `relationship(... passive_deletes=True)` where
+parent cascades. Add a `worklog_entries` relationship to `Case` and a
+back-reference on `Person` if convenient (mirror how `Note`/`PersonRole` relate to
+`Case`). Use `datetime.now(timezone.utc)` / `func.now()` — never bare `datetime.now()`.
+
+---
+
+## 5. Backend Implementation
+
+### 5.1 `models.py`
+Add `VoiceLog`, `WorklogEntry`, `WorklogEntryPerson` per §4. Place them near the other
+case-related child tables. Add relationships to `Case` (and optionally `Person`).
+
+### 5.2 Migration
+- Preferred: `alembic revision --autogenerate -m "add worklog tables"` → review the
+  generated file (autogenerate misses partial indexes; this model has none, so it
+  should be clean) → `alembic upgrade head`.
+- The generated file should mirror
+  `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`. `down_revision` will be
+  set to the current head automatically.
+
+### 5.3 `db/worklog.py`
+Mirror `db/notes.py`. Functions:
+
+```python
+def create_worklog(transcript, log_date, created_by, entries) -> dict
+# entries: list of {case_id|None, minutes, description, raw_reference, person_ids: [int]}
+# Creates the VoiceLog + all WorklogEntry rows + people junction rows in ONE transaction.
+
+def get_worklog_by_case(case_id) -> dict
+# Returns entries for a case, newest first, grouped/orderable by activity_date,
+# each with its people (id+name) and a total-minutes summary.
+
+def get_worklog_by_person(person_id) -> dict
+# Returns entries that name this person, newest first, each with its case (id+name).
+
+def delete_worklog_entry(entry_id) -> bool
+def update_worklog_entry(entry_id, **fields) -> dict | None  # edit minutes/description/case_id/people post-hoc
+```
+
+Use `SessionLocal()` context manager, `flush()/refresh()` before building the dict,
+`commit()` last. Add `_entry_to_dict()` using `WorklogEntryOut`. Eager-load people and
+case names with `selectinload`/joins to avoid N+1.
+
+Export all functions in `db/__init__.py` (import block + `__all__`).
+
+### 5.4 `services/worklog_extractor.py`
+A near-twin of `services/case_extractor.py`. Responsibilities:
+
+1. Accept the raw `transcript`, the `log_date`, and **candidate context**: a compact list
+   of the firm's active cases (`id`, `case_name`, `short_name`) and contacts
+   (`id`, `name`, `organization`). Pull these via existing `db` queries (e.g. a light
+   case list + `db.persons` list). Keep the lists lean (id + name) to control tokens;
+   prompt-cache them if they get large (see `services/chat/client.py` for the
+   `cache_control` pattern).
+2. Call Claude (`settings.extraction_model`) with a **single forced tool** —
+   `submit_worklog` — whose input schema is a list of entries:
+
+```python
+SUBMIT_WORKLOG_TOOL = {
+    "name": "submit_worklog",
+    "description": "Submit the structured work-log entries extracted from the memo.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "entries": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "description": {"type": "string", "description": "Concise summary of the work done."},
+                        "minutes": {"type": "integer", "description": "Estimated duration in minutes."},
+                        "case_id": {"type": ["integer", "null"], "description": "ID of the matched case, or null if no confident match."},
+                        "case_guess": {"type": "string", "description": "The case name as the user referred to it (for display when unmatched)."},
+                        "person_ids": {"type": "array", "items": {"type": "integer"}, "description": "IDs of matched people mentioned in this activity."},
+                        "raw_reference": {"type": "string", "description": "The original phrase from the memo this entry came from."}
+                    },
+                    "required": ["description", "minutes", "raw_reference"]
+                }
+            }
+        },
+        "required": ["entries"]
+    }
+}
+```
+
+3. Use `tool_choice={"type": "tool", "name": "submit_worklog"}`, read `block.input["entries"]`.
+4. `record_usage_from_message(source="worklog_extractor", request_type="parse_worklog", model=..., message=message)`.
+5. Return the entries list (the route hands it to the frontend for review; it is NOT
+   saved yet).
+
+**System prompt must encode the philosophy and the two-pass logic.** Sketch:
+
+```
+You convert a lawyer's informal end-of-day memo into discrete work-log entries.
+
+STEP 1 — SPLIT: Break the memo into separate activities. Each activity is a distinct
+piece of work tied to a single case. "Drafted discovery for Armstrong, then a call
+with Tanner about Reyes, then back to the Armstrong opposition" = THREE activities.
+
+STEP 2 — ESTIMATE TIME (treat the day as a budget): Assign each activity a duration in
+minutes using context. Rules of thumb:
+  - A phone call / quick call with no stated length ≈ 30 minutes.
+  - "Spent the morning / the afternoon on X" ≈ 210–240 minutes IF nothing else competes
+    for that block; if the morning contains several activities, divide the block among
+    them sensibly.
+  - A short task ("sent an email", "reviewed a doc") ≈ 10–20 minutes.
+  - Never inflate. If duration is truly unknowable and there's no anchor, estimate
+    conservatively. Do NOT ask the user for clarification — just estimate.
+  - Do not let the day's total exceed what the memo implies (don't fill the morning AND
+    log a separate 3-hour morning call).
+
+STEP 3 — MATCH: For each activity, match the case to the provided case list by name
+(fuzzy is fine — "Armstrong" → the case whose name contains Armstrong). Match named
+people to the contact list. If you cannot confidently match a case, set case_id=null
+and put the user's phrasing in case_guess. Same for people (omit unmatched). ALWAYS
+fill raw_reference with the original phrase.
+
+Use the submit_worklog tool. Provide entries in the order they occurred.
+```
+
+> **Matching note:** The model does the matching from the supplied lists. As a
+> belt-and-suspenders improvement (optional), the route can run any `case_id=null`
+> entries through the existing `db.fuzzy_search_persons_db` / case search to offer a
+> best-guess in the review UI. Not required for v1.
+
+### 5.5 `schemas/inputs.py` and `schemas/outputs.py`
+**Inputs:**
+```python
+class WorklogEntryInput(BaseModel):
+    case_id: Optional[int] = None
+    minutes: int
+    description: str
+    raw_reference: Optional[str] = None
+    person_ids: list[int] = []
+
+class ParseWorklogInput(BaseModel):
+    transcript: str
+    log_date: Optional[str] = None  # YYYY-MM-DD; defaults to today server-side
+
+class SaveWorklogInput(BaseModel):
+    transcript: str
+    log_date: Optional[str] = None
+    entries: list[WorklogEntryInput]
+```
+**Outputs:** `WorklogEntryOut` (`from_attributes=True`: id, case_id, minutes, description,
+raw_reference, activity_date, created_at, plus nested `people: list[{id,name}]` and
+optional `case_name`/`short_name`). A `ParsedWorklogEntryOut` for the parse response
+(includes `case_guess`). Mirror `NoteOut`. No `__all__` needed — re-exported by `import *`.
+
+### 5.6 `routes/worklog.py` → `register_worklog_routes(mcp)`
+Mirror `routes/notes.py`. Endpoints (all `auth.require_auth`, all DB calls via
+`asyncio.to_thread`):
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/v1/worklog/parse` | Body `ParseWorklogInput`. Calls the extractor, returns parsed entries (NOT saved). |
+| POST | `/api/v1/worklog` | Body `SaveWorklogInput`. Persists via `db.create_worklog`. Returns the saved rows. |
+| GET | `/api/v1/worklog/by-case/{case_id}` | Entries + total minutes for a case. |
+| GET | `/api/v1/worklog/by-person/{person_id}` | Entries for a contact. |
+| PATCH | `/api/v1/worklog/entries/{entry_id}` | Edit an entry post-hoc (optional v1.1). |
+| DELETE | `/api/v1/worklog/entries/{entry_id}` | Delete an entry (optional v1.1). |
+
+Get the current user via `auth.get_current_user(request)` for `created_by`. Register in
+`routes/__init__.py` **before** the static block; add to `__all__`.
+
+### 5.7 MCP tool (secondary — include if time allows)
+Add `log_work` to `tools.py` so the user can also log via Claude chat. Keep it **thin**:
+accept already-structured entries (Claude resolves cases/people itself using the existing
+`search` tool, exactly like `import_case` does) and call `db.create_worklog`. Then:
+- Add an input model `LogWorkInput` to `schemas/inputs.py`.
+- Document it in `MCP_INSTRUCTIONS` (`main.py`, tools-overview section ~lines 30–41) —
+  this string is hand-maintained and required.
+
+### 5.8 Dockerfile
+**No change needed.** All new files land in already-copied directories (`db/`, `routes/`,
+`services/`, `schemas/`). (Only update the Dockerfile if you add a brand-new top-level
+file or directory.)
+
+---
+
+## 6. Frontend Implementation
+
+Repeatable order (per CLAUDE.md): **types → service → components → page → wire-in.**
+
+### 6.1 Types — `frontend/src/types/worklog.ts`
+```ts
+export interface WorklogEntry {
+  id: number
+  case_id: number | null
+  case_name: string | null
+  short_name: string | null
+  minutes: number
+  description: string
+  raw_reference: string | null
+  activity_date: string
+  created_at: string
+  people: { id: number; name: string }[]
+}
+export interface ParsedWorklogEntry {
+  description: string
+  minutes: number
+  case_id: number | null
+  case_guess: string | null
+  person_ids: number[]
+  people: { id: number; name: string }[]
+  raw_reference: string
+}
+```
+
+### 6.2 Service — `frontend/src/services/worklog.ts`
+Mirror `services/cases.ts` (`apiFetch` from `@/lib/api`). Functions:
+`parseWorklog(transcript, logDate)`, `saveWorklog(payload)`,
+`getWorklogByCase(caseId)`, `getWorklogByPerson(personId)`, and (optional)
+`updateWorklogEntry`, `deleteWorklogEntry`.
+
+### 6.3 Page — `frontend/src/pages/worklog/index.tsx` (+ `components/`)
+A dedicated page (co-located feature module). Flow:
+1. **Compose:** a large `<Textarea>` + a date picker (defaults to today). A "Parse"
+   button. (Add a small hint that they can dictate with their phone keyboard's mic.)
+2. On Parse → `useMutation(parseWorklog)`; show a loading state.
+3. **Review:** render the parsed entries as an **editable list**
+   (`components/worklog-review.tsx`):
+   - Each row: editable description, a `minutes` input (or quick chips: 15/30/60/90/morning),
+     a **case combobox** (searchable, prefilled with the match; shows `case_guess` as a
+     warning chip when `case_id` is null), and a **people multi-select**.
+   - Running **total for the day** displayed at the top.
+   - Use shadcn `Command`/`Combobox`, `Input`, `Badge`, `Button`. Check exact APIs via the
+     shadcn MCP. **Square corners**, Hugeicons, semantic tokens.
+4. **Save:** `useMutation(saveWorklog)` → on success, clear/redirect and invalidate any
+   relevant queries. Toast confirmation.
+
+Keep mislink-fixing to a **single glance** — do not gate saving behind required fields
+(unmatched entries save fine with `case_id = null`).
+
+### 6.4 Case detail card — `frontend/src/pages/cases/components/case-work-log.tsx`
+`useQuery(["worklog-by-case", caseId], () => getWorklogByCase(caseId))`. Render entries
+grouped by `activity_date` (use the existing `frontend/src/lib/datetime.ts` helpers —
+`formatDateHeader`, `getDateKey`), each showing description, minutes, and people chips;
+show a **total time** for the case at the card header. Mount it in
+`frontend/src/pages/cases/detail.tsx` near `<CaseActivityFeed />` (~line 315).
+Recommendation: **always-on** (don't gate behind `feature_toggles`).
+
+### 6.5 Contact "Interactions" section — in `contact-detail-dialog.tsx`
+Add a section (`useQuery(["worklog-by-person", personId], ...)`) listing the activities
+that named this person, by date, each linking to its case. Place it alongside the
+existing SMS / roles sections.
+
+### 6.6 Wire-in (locate these files first)
+- **Router:** add a `/log` route pointing at `pages/worklog/index.tsx` (React Router v7 —
+  find the route table, likely `App.tsx` or a dedicated router file).
+- **Header/nav:** add a global "Log my day" button (Hugeicons mic/pencil icon) in the app
+  header/sidebar (`frontend/src/components/layout/`). It navigates to `/log`.
+
+---
+
+## 7. Build Sequence (recommended order)
+
+1. `models.py` → add the three models (+ relationships).
+2. `alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
+3. `schemas/inputs.py` + `schemas/outputs.py` → add the models.
+4. `db/worklog.py` → CRUD/queries; export in `db/__init__.py`.
+5. `services/worklog_extractor.py` → the LLM parse.
+6. `routes/worklog.py` → endpoints; register in `routes/__init__.py` (before static).
+7. (Optional) `tools.py` `log_work` + `MCP_INSTRUCTIONS` in `main.py`.
+8. Restart backend with `/dev`; smoke-test the API with `curl` (parse → save → by-case → by-person).
+9. Frontend: types → service → review component → page → case card → contact section → router + header.
+10. `cd frontend && npm run type-check && npm run build`; visual pass via `/dev`.
+
+---
+
+## 8. Verification Checklist
+
+**Backend**
+- [ ] `alembic upgrade head` applies cleanly; `alembic check` reports models in sync.
+- [ ] `POST /api/v1/worklog/parse` with a multi-case memo returns multiple entries with
+      sane minutes and correct case/person matches; an unknown case → `case_id null` +
+      `case_guess` populated.
+- [ ] `POST /api/v1/worklog` persists VoiceLog + entries + people junction in one txn.
+- [ ] `GET /api/v1/worklog/by-case/{id}` and `/by-person/{id}` return correct data + totals.
+- [ ] Token usage recorded (row in `token_usage_log` with `source='worklog_extractor'`).
+- [ ] Unauthed requests get 401 (auth dependency present on every route).
+
+**Frontend**
+- [ ] `npm run type-check` and `npm run build` pass.
+- [ ] `/log` page: type a memo → Parse → editable review → fix a mislink → Save → toast.
+- [ ] Case detail shows the Work Log card with grouped-by-day entries and a total.
+- [ ] Contact dialog shows the Interactions section.
+- [ ] Square corners, Hugeicons, semantic color tokens, `@/` imports throughout.
+
+**Behavioral (the philosophy)**
+- [ ] "Had a call with X" with no duration → ~30 min, no prompt for clarification.
+- [ ] "Spent the morning on Y" (sole morning item) → ~3.5–4 hrs.
+- [ ] A memo mixing several cases fans out correctly; the day isn't double-counted.
+
+---
+
+## 9. Open Decisions for the Implementer
+
+1. **Active-case scope for matching context.** Pull *all* non-closed cases, or only the
+   logged-in user's cases (`attorney_ids`/`paralegal_ids`)? Recommendation: the user's
+   cases first; fall back to all if the count is small. Keep the candidate list lean to
+   control tokens (prompt-cache it if large).
+2. **Editing/deleting entries after save** (PATCH/DELETE endpoints + UI) — listed as
+   optional v1.1. Decide whether to ship in v1.
+3. **MCP `log_work` tool** — secondary. Ship if time allows; it makes logging-via-Claude
+   possible and fits the MCP-first architecture.
+4. **`minutes` display format** — store integer minutes; render as "1h 30m" / "30m" via a
+   small formatter in `frontend/src/lib/`.
+5. **Multi-user.** `created_by` is captured. Decide whether case/contact views show
+   everyone's entries or filter to the current user (the firm is small; default to
+   showing all, label with initials if needed).
+
+---
+
+## 10. Guardrails (from CLAUDE.md — don't trip these)
+
+- **UTC in the DB**, Pacific for display. `DateTime(timezone=True)` everywhere;
+  `datetime.now(timezone.utc)`/`func.now()` for writes; never bare `datetime.now()`.
+- **Route order:** new routes before `register_static_routes` (SPA catch-all is last).
+- **MCP_INSTRUCTIONS** is hand-maintained — update it if you add the MCP tool.
+- **Production runs `-w 1`** — irrelevant here (no in-memory state added), just don't
+  change it.
+- **Square corners**, **Hugeicons** (not Lucide), **`@/` imports**, **kebab-case files**,
+  semantic color tokens. Use the **shadcn MCP** + **Context7** to confirm component APIs
+  before writing UI.
+- Never push to `main`; this work stays on `claude/voice-log-case-contact-Qgp6Y`.

--- a/docs/plans/worklog-feature-plan.md
+++ b/docs/plans/worklog-feature-plan.md
@@ -1,493 +1,500 @@
 # Implementation Plan — Work Log (Voice-Driven Activity Logging)
 
-> **Status:** Ready to implement. This plan was developed against the current
-> codebase (branch `claude/voice-log-case-contact-Qgp6Y`) with all file paths,
-> patterns, and the current Alembic head verified. Hand this to a local Claude
-> session that has the database, Python deps, and dev servers available.
+> **Status:** Ready to implement. Developed against the current codebase (branch
+> `claude/voice-log-case-contact-Qgp6Y`) with all file paths, patterns, and the current
+> Alembic head verified. Hand this to a local Claude session that has the database,
+> Python deps, and dev servers available.
 
 ---
 
 ## 1. The Feature (what we're building and why)
 
-The user (an attorney) wants to record a short, **stream-of-consciousness voice/text
-memo once or twice a day** describing what they worked on — e.g. *"I spent the
-morning on the opposition to the motion to dismiss in the Armstrong case, then had
-a call with Tanner Navaroli about the Reyes matter, then drafted discovery for
-Armstrong again."*
+The user (an attorney) wants to record a short, **stream-of-consciousness memo once or
+twice a day** describing what they worked on — *"I spent the morning on the opposition
+to the motion to dismiss in the Armstrong case, then had a call with Tanner Navaroli
+about the Reyes matter, then drafted discovery for Armstrong again."* — and have it
+turned into discrete, time-estimated **work-log entries** linked to cases (and people).
 
-The system turns that unstructured dump into discrete, time-estimated **work log
-entries**, each linked to a case (and optionally to people), so that later the user
-can:
+Crucially, **the system already knows about a lot of the day's work** — calendared
+events (depositions, hearings), tasks completed/updated that day, and calls logged in the
+activity feed. So instead of making the user re-describe those, the system **surfaces
+them for one-tap selection**. The user only free-types what *isn't* already captured.
 
-- Open a **case** and see everything they did on it, by day, with a rough time total.
-- Open a **contact** and see every time they interacted with that person.
+Later, the user can open a **case** and see everything they did on it, by day, with a
+rough time total — and open a **contact** and see every interaction with that person.
 
-### Design philosophy (important — these shape every decision)
+### Design philosophy (these shape every decision)
 
-- **This is NOT a time tracker.** No start/stop, no 10:00–11:00 precision. The goal
-  is *broad strokes* — a habit of recording work so the user gets a rough sense of
-  effort per case over time.
-- **No nitpicky follow-up questions.** If the user doesn't say how long something
-  took, the system **estimates** using sensible defaults. It never interrogates.
-- **Estimates from context.** "Had a call" → default ~30 min. "Spent the morning on
-  X" with nothing else competing for the morning → ~3.5–4 hrs. The model reasons
-  about the *whole day as a budget*.
+- **This is NOT a time tracker.** No start/stop, no 10:00–11:00 precision. The goal is
+  *broad strokes* — a low-effort habit that yields a rough sense of effort per case.
+- **Never make the user re-describe what's already in the system.** Surface it; let them
+  select it.
+- **No nitpicky follow-up questions.** The AI estimates durations from context. It never
+  interrogates.
+- **A realistic day, capped.** The AI consolidates everything into a believable **5–7
+  working-hour day** and **never exceeds ~7 hours** total. It estimates task durations
+  itself rather than using rigid per-item defaults.
 
 ---
 
-## 2. Design Decisions (already resolved with the user — do not re-litigate)
+## 2. The Three-Phase Flow (the core UX — resolved with the user)
+
+The `/log` page walks through three phases. **Phase 3 can happen immediately after Phase
+2, or be deferred to later** — so the consolidated result is **persisted as a draft** and
+remains confirmable later.
+
+### Phase 1 — Input
+Two lanes that merge:
+- **Surfaced items (multi-select):** a pre-built list of things already on record for the
+  selected date — **events**, **completed/updated tasks**, and **case comments / activity-feed
+  items** (calls *and* any other logged work — a comment usually reflects something that took
+  time). Each is pre-filled with its case and description. The user just ticks the ones that
+  represent real work-time.
+- **Free-form writing:** a textarea for everything not already captured.
+
+### Phase 2 — Consolidation (AI)
+The AI receives the **selected surfaced items + the free-text memo + candidate
+cases/contacts**, and in a single call:
+1. **Splits** the memo into discrete activities (one activity = one case).
+2. **Estimates durations** — including estimating **task** durations from their
+   descriptions (not fixed defaults). Events with a real start/end time keep their actual
+   length.
+3. **Apportions a realistic working day** — total lands in **~5–7 hours** and **never
+   exceeds 7 hours (420 min)**.
+4. **Matches** each activity to a case and to people from the candidate lists; unmatched →
+   `case_id = null` with the raw phrasing preserved.
+
+The result is **saved as a draft** (`voice_logs.status = 'draft'`) and returned for review.
+
+### Phase 3 — Confirmation
+A **one-glance, editable** review: the user confirms/fixes case links, people, and
+durations, then confirms. On confirm, the draft flips to `confirmed`. **Drafts not
+confirmed remain in a "needs review" list** so confirmation can happen later. Only
+**confirmed** entries count toward case/contact totals.
+
+---
+
+## 3. Design Decisions (resolved — do not re-litigate)
 
 | Decision | Resolution |
 |---|---|
 | Fan-out | **One memo → many activities.** A single dump splits into N entries. |
 | Activity ↔ case | **Each activity belongs to exactly one case** (or none → unmatched). |
-| Time granularity | **Per-activity** `minutes` estimate. Each entry gets its own duration. |
-| Activity ↔ people | **Many-to-many.** One activity (e.g. a meeting) can name several people. |
-| Unknown names | **Preserve raw text, leave unlinked.** Never drop the original phrase. If a case/person isn't found, save the entry with `case_id = NULL` and keep `raw_reference`. |
-| Review step | **One-glance, editable, non-blocking.** After parsing, show the parsed entries as an editable list; user can fix a mislinked case/person or nudge minutes, then Save. Nothing persists until confirmed. This is NOT the "nitpicky questions" the user dislikes — it's a single confirmation screen. |
-| Audio | **Do NOT store audio.** Text only. For the MVP the user dictates with their phone's native dictation (or pastes) into a textarea. Transcription/audio capture is explicitly out of scope. |
-| Time estimation | **Two-pass within a single LLM call:** (1) split the memo into discrete activities, (2) divide the day's time across them so "the morning" can't be double-counted. |
-| Entry point | **Dedicated `/log` page + a global button in the app header.** Logging spans multiple cases, so it cannot live on a single case page. |
-| Naming | Use the domain name **`worklog`** internally. **Do NOT use `activity`** — that namespace is already taken (see §3). User-facing copy can say "Work Log" / "Activities". |
+| Time granularity | **Per-activity** `minutes`. Each entry has its own duration. |
+| Activity ↔ people | **Many-to-many.** One activity can name several people. |
+| Unknown names | **Preserve raw text, leave unlinked** (`case_id = null`, keep `raw_reference`/`case_guess`). |
+| Surfaced items | **Multi-select** from events, completed/updated tasks, and case comments (activity-feed items) for the date — a comment usually reflects work that took time. Don't make the user re-describe them. |
+| Link vs copy | **Link, don't copy.** A selected item becomes an entry that *references* its source via `source_type` + `source_id` (no duplication, no drift, no re-surfacing). Free-typed entries are `source_type = 'manual'`. |
+| Time estimation | **AI estimates** (incl. task durations). Two-pass: split → estimate/apportion → match. |
+| Day budget | **Target ~5–7 hrs; hard ceiling ~7 hrs.** Anchored items (events with real times) keep their length; flexible work absorbs the remainder. |
+| Review | **One-glance, editable, non-blocking.** Unmatched entries still save fine. |
+| Deferred confirm | **Consolidation persists a draft**; confirmation can happen now or later. Only confirmed entries count. |
+| Audio | **Do NOT store audio.** Text only (phone dictation / paste). |
+| Entry point | **Dedicated `/log` page + a global button in the app header.** |
+| Naming | Domain = **`worklog`**. **Do NOT use `activity`** — already taken (see §4). |
 
 ---
 
-## 3. Critical Codebase Facts (verified — saves you rediscovery)
+## 4. Critical Codebase Facts (verified — saves rediscovery)
 
 ### Naming collision to avoid
-`routes/activity.py` + `db/activity.py` + `register_activity_routes` already exist and
-implement **page-view analytics** (`POST /api/v1/tracking/pageview`,
-`GET /api/v1/activity/summary`, etc.). The frontend `CaseActivityFeed` is a
-**comment/system-event feed** backed by `case_comments`, not work logging. **Keep the
-new feature in a separate `worklog` namespace** to avoid colliding with both.
+`routes/activity.py` + `db/activity.py` + `register_activity_routes` already implement
+**page-view analytics**. The frontend `CaseActivityFeed` is a **comment/system-event
+feed** backed by `case_comments`. **Keep the new feature in a `worklog` namespace.**
+
+### Where the "surfaced item" sources live (verified)
+- **Events:** `events` table (`models.py` ~496). Filter by `date == log_date`. `event_type`,
+  `time`, `end_date`, `description`, `case_id`, `attendee_ids`. DB module: `db/events.py`.
+- **Tasks:** `tasks` table (`models.py` ~802). "Done today" = `completion_date == log_date`;
+  also consider `status` changes via `updated_at::date == log_date`. DB module: `db/tasks.py`.
+- **Case comments (the "comments" lane):** the activity feed is backed by `case_comments`
+  (`db/case_comments.py`) — and a polymorphic `comments` table exists too (`db/comments.py`,
+  `entity_type`/`entity_id`). **Treat user-authored (non-`is_system`) `case_comments` created
+  on `log_date` as candidate work items** — a comment usually reflects something that took the
+  user time (a call, a review, a follow-up). This is broader than "calls": any non-system
+  comment is a legitimate candidate. (Note: structured *interactions* currently exist only for
+  **intakes** — `intake_comments` with `detail={type:'interaction',...}` via
+  `services/interaction_summarizer.py`; cases have no structured interaction type yet, so the
+  generic comment is the right hook.) **Skip `is_system` comments** (they're auto-generated
+  audit lines like "X added a note", not work). **Confirm exact source at implementation time.**
 
 ### Current Alembic head
-- **Head revision: `d2cd156b344a`** (file
-  `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`). Single head, verified.
-- Your new migration's `down_revision` must be `'d2cd156b344a'` — **unless** you use
-  `alembic revision --autogenerate` (preferred, since you have a live DB), which sets
-  it automatically. Re-verify the head at implementation time with `alembic heads`.
+- **Head: `d2cd156b344a`** (`alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`).
+  Single head, verified. Prefer `alembic revision --autogenerate` (you have a live DB),
+  which sets `down_revision` automatically. Re-verify with `alembic heads`.
 
 ### Patterns to mirror (exact reference files)
-- **Migration format:** `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`
-- **DB module:** `db/notes.py` — `SessionLocal()` context manager, `_x_to_dict()`
-  helper using the Pydantic Out schema, `flush()/refresh()/commit()` ordering.
-- **DB exports:** `db/__init__.py` — import block (~line 168 for notes) + `__all__`
-  list (~line 524). Add your new functions to both.
+- **Migration:** `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`
+- **DB module:** `db/notes.py` — `SessionLocal()` ctx mgr, `_x_to_dict()` via the Out schema,
+  `flush()/refresh()/commit()` order. Exports in `db/__init__.py` (import block ~168 + `__all__` ~524).
 - **Routes:** `routes/notes.py` — `@mcp.custom_route(...)`, `auth.require_auth(request)`,
-  `asyncio.to_thread(db.fn, ...)`, `pydantic_error(e)` / `api_error(...)` from `.common`.
-- **Route registration:** `routes/__init__.py` — import (~lines 35–66), call
-  `register_worklog_routes(mcp)` **before** `register_static_routes(mcp)` (currently
-  line 152), and add to `__all__` (~line 156). **Static must stay last** (SPA catch-all).
-- **Input schemas:** `schemas/inputs.py` — plain `BaseModel`s, no `__all__` (picked up by
-  `from .inputs import *` in `schemas/__init__.py`). Note pattern at lines 113–119.
-- **Output schemas:** `schemas/outputs.py` — `model_config = ConfigDict(from_attributes=True)`;
-  `model_dump(mode="json")` auto-ISO-formats datetimes. `NoteOut` at lines 97–110,
-  `PersonOut` at 357–369 are good templates.
-- **LLM extraction:** `services/case_extractor.py` — sync `anthropic.Anthropic` client,
-  `tool_choice={"type": "tool", "name": "..."}` to FORCE structured output, read
-  `block.input` from the `tool_use` block, and
+  `auth.get_current_user(request)`, `asyncio.to_thread(db.fn, ...)`, `pydantic_error(e)` /
+  `api_error(...)` from `.common`. Register in `routes/__init__.py` **before**
+  `register_static_routes(mcp)` (line 152); add to `__all__` (~156).
+- **Input schemas:** `schemas/inputs.py` — plain `BaseModel`, no `__all__` (re-exported by
+  `from .inputs import *`). **Output schemas:** `schemas/outputs.py` —
+  `ConfigDict(from_attributes=True)`; `model_dump(mode="json")` ISO-formats datetimes.
+  `NoteOut` (97–110) and `PersonOut` (357–369) are templates.
+- **LLM extraction:** `services/case_extractor.py` — sync `anthropic.Anthropic`,
+  `tool_choice={"type":"tool","name":...}` to FORCE structured output, read `block.input`,
   `db.token_usage.record_usage_from_message(source=..., request_type=..., model=..., message=...)`.
-  Model comes from `settings.extraction_model` (`config.py`), API key from
-  `os.environ["ANTHROPIC_API_KEY"]`.
-- **MCP tool:** `tools.py` `manage_note` (~line 1292) — `@mcp.tool()`, helpers
-  `validation_error()`, `error_response()`, `not_found_error()`; `Context` carries
-  `case_context` for the currently-viewed case. Registered inside `register_tools(mcp)`.
-- **MCP instructions:** `main.py` `MCP_INSTRUCTIONS` string (~lines 26–69; tools overview
-  ~30–41). **Hand-maintained** — must be updated when adding an MCP tool.
+  Model = `settings.extraction_model` (`config.py`); key = `os.environ["ANTHROPIC_API_KEY"]`.
+  Prompt-cache large candidate lists via the `cache_control` pattern in `services/chat/client.py`.
+- **MCP tool:** `tools.py` `manage_note` (~1292) — `@mcp.tool()`, helpers `validation_error()`,
+  `error_response()`, `not_found_error()`; `Context.case_context`. Registered in `register_tools(mcp)`.
+- **MCP instructions:** `main.py` `MCP_INSTRUCTIONS` (~26–69, tools overview ~30–41) — hand-maintained.
 
 ### Frontend facts
-- **Case detail page:** `frontend/src/pages/cases/detail.tsx` — renders
-  `<CaseNotesPanel .../>` and `<CaseActivityFeed caseId={caseData.id} />` in a right
-  column (~line 315). Add the new Work Log card here.
-- **Activity feed component (pattern reference):**
-  `frontend/src/pages/cases/components/case-activity-feed.tsx` — TanStack Query
-  (`useQuery`), service call, card layout.
-- **Contact detail dialog:** `frontend/src/components/common/contact-detail-dialog.tsx` —
-  sections for contact info, an SMS section, and roles-by-case. Add an "Interactions"
-  (work-log) section here.
-- **Service pattern:** `frontend/src/services/cases.ts` — `apiFetch` from `@/lib/api`,
-  `URLSearchParams`, `res.ok` checks. **Types** in `frontend/src/types/case.ts`.
-- **Feature toggles:** `case.feature_toggles` (JSONB) gated via `isCaseFeatureEnabled(...)`.
-  Decide whether the case Work Log card is always-on or toggle-gated (recommendation:
-  **always-on**, since logging is global, not a per-case opt-in section).
-- **Conventions (from CLAUDE.md):** `@/` import alias always; `kebab-case.tsx` files;
-  **square corners** (no `rounded-*`); semantic color tokens (`--success`, etc.);
-  **Hugeicons** (not Lucide); TanStack Query for server state; React Hook Form + Zod for
-  forms; shadcn primitives via `npx shadcn@latest add`. Use the shadcn MCP to check
-  component APIs before writing UI.
-- **To locate at implementation time** (not verified here): the **router** (React Router
-  v7 route table — likely `frontend/src/App.tsx` or a `routes`/`router` file) and the
-  **app header/sidebar** (`frontend/src/components/layout/` per CLAUDE.md, e.g.
-  `app-sidebar.tsx` / a header component). Add the `/log` route and the global nav button
-  there.
+- **Case detail:** `frontend/src/pages/cases/detail.tsx` renders `<CaseNotesPanel/>` and
+  `<CaseActivityFeed caseId={...}/>` in a right column (~315). Mount the new Work Log card here.
+- **Feed pattern:** `frontend/src/pages/cases/components/case-activity-feed.tsx` (TanStack Query + card).
+- **Contact dialog:** `frontend/src/components/common/contact-detail-dialog.tsx` — add an
+  "Interactions" section alongside contact-info / SMS / roles.
+- **Service pattern:** `frontend/src/services/cases.ts` (`apiFetch` from `@/lib/api`).
+  **Types:** `frontend/src/types/case.ts`. **Datetime helpers:** `frontend/src/lib/datetime.ts`
+  (`formatDateHeader`, `getDateKey`).
+- **Conventions:** `@/` imports; `kebab-case.tsx`; **square corners** (no `rounded-*`);
+  semantic color tokens; **Hugeicons** (not Lucide); TanStack Query; React Hook Form + Zod;
+  shadcn via `npx shadcn@latest add` (check APIs with the shadcn MCP + Context7).
+- **Locate at implementation time:** the **router** (React Router v7 — likely
+  `frontend/src/App.tsx` or a router file) for the `/log` route, and the **app header/sidebar**
+  (`frontend/src/components/layout/`) for the global "Log my day" button.
 
 ---
 
-## 4. Data Model
+## 5. Data Model
 
-Three new tables. **Preferred workflow:** add the SQLAlchemy models to `models.py`, then
-run `alembic revision --autogenerate -m "add worklog tables"`, review, and
-`alembic upgrade head`. (`models.py` is the schema source of truth.)
+Three new tables + two reference columns. Prefer: edit `models.py`, then
+`alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
 
-### `voice_logs` — one row per brain-dump
+### `voice_logs` — one row per session/brain-dump
 | column | type | notes |
 |---|---|---|
 | `id` | Integer PK | |
-| `transcript` | Text, not null | the raw text the user typed/dictated |
-| `log_date` | Date, not null | the date the work happened (defaults to today, editable in UI) |
-| `created_by` | Integer FK → `users.id` ON DELETE SET NULL, nullable | who logged it |
-| `created_at` | DateTime(timezone=True), server_default CURRENT_TIMESTAMP | |
+| `transcript` | Text, nullable | the raw free-text (may be empty if the day was all surfaced items) |
+| `log_date` | Date, not null | the date the work happened (defaults today, editable) |
+| `status` | String(20), not null, default `'draft'` | `'draft'` \| `'confirmed'` |
+| `created_by` | Integer FK→`users.id` SET NULL, nullable | who logged it |
+| `created_at` | DateTime(tz=True), default CURRENT_TIMESTAMP | |
+| `confirmed_at` | DateTime(tz=True), nullable | set when confirmed |
 
-### `worklog_entries` — the split-out, time-estimated activities
+### `worklog_entries` — the consolidated, time-estimated activities
 | column | type | notes |
 |---|---|---|
 | `id` | Integer PK | |
-| `voice_log_id` | Integer FK → `voice_logs.id` ON DELETE CASCADE, not null | |
-| `case_id` | Integer FK → `cases.id` ON DELETE SET NULL, **nullable** | NULL = unmatched |
-| `minutes` | Integer, not null | estimated duration |
-| `description` | Text, not null | concise summary of the work |
-| `raw_reference` | Text, nullable | the original phrase from the memo (always preserved, esp. when unmatched) |
-| `activity_date` | Date, not null | denormalized from the voice_log's `log_date` for easy per-case/day queries |
-| `created_at` | DateTime(timezone=True), server_default CURRENT_TIMESTAMP | |
+| `voice_log_id` | Integer FK→`voice_logs.id` CASCADE, not null | |
+| `case_id` | Integer FK→`cases.id` SET NULL, **nullable** | NULL = unmatched |
+| `minutes` | Integer, not null | AI estimate, user-adjustable |
+| `description` | Text, not null | concise summary |
+| `raw_reference` | Text, nullable | original phrase / case_guess (preserved, esp. unmatched) |
+| `activity_date` | Date, not null | denormalized from `log_date` for per-case/day queries |
+| `source_type` | String(20), nullable | `'manual'` \| `'event'` \| `'task'` \| `'comment'` |
+| `source_id` | Integer, nullable | id of the linked event/task/case_comment (NULL for manual) |
+| `created_at` | DateTime(tz=True), default CURRENT_TIMESTAMP | |
 
-Indexes: `case_id`, `voice_log_id`, `activity_date`.
+Indexes: `case_id`, `voice_log_id`, `activity_date`, `(source_type, source_id)`.
 
 ### `worklog_entry_people` — junction (entry ↔ persons, many-to-many)
 | column | type | notes |
 |---|---|---|
-| `entry_id` | Integer FK → `worklog_entries.id` ON DELETE CASCADE | composite PK |
-| `person_id` | Integer FK → `persons.id` ON DELETE CASCADE | composite PK |
+| `entry_id` | Integer FK→`worklog_entries.id` CASCADE | composite PK |
+| `person_id` | Integer FK→`persons.id` CASCADE | composite PK |
 
-Index: `person_id` (for the "click a contact → see interactions" query).
+Index: `person_id`.
 
-**SQLAlchemy notes:** follow the `models.py` conventions exactly —
-`Mapped[...]`/`mapped_column`, `DateTime(timezone=True)` for all timestamps (UTC),
-`server_default=text("CURRENT_TIMESTAMP")`, explicit `ForeignKeyConstraint` +
-`Index` in `__table_args__`, and `relationship(... passive_deletes=True)` where
-parent cascades. Add a `worklog_entries` relationship to `Case` and a
-back-reference on `Person` if convenient (mirror how `Note`/`PersonRole` relate to
-`Case`). Use `datetime.now(timezone.utc)` / `func.now()` — never bare `datetime.now()`.
+**SQLAlchemy notes:** follow `models.py` conventions — `Mapped`/`mapped_column`,
+`DateTime(timezone=True)` (UTC), `server_default=text("CURRENT_TIMESTAMP")`, explicit
+`ForeignKeyConstraint`+`Index` in `__table_args__`, `relationship(..., passive_deletes=True)`.
+Add a `worklog_entries` relationship to `Case`. Use `func.now()` / `datetime.now(timezone.utc)`.
 
 ---
 
-## 5. Backend Implementation
+## 6. Backend Implementation
 
-### 5.1 `models.py`
-Add `VoiceLog`, `WorklogEntry`, `WorklogEntryPerson` per §4. Place them near the other
-case-related child tables. Add relationships to `Case` (and optionally `Person`).
+### 6.1 `models.py`
+Add `VoiceLog`, `WorklogEntry`, `WorklogEntryPerson` (§5) + a `Case.worklog_entries` relationship.
 
-### 5.2 Migration
-- Preferred: `alembic revision --autogenerate -m "add worklog tables"` → review the
-  generated file (autogenerate misses partial indexes; this model has none, so it
-  should be clean) → `alembic upgrade head`.
-- The generated file should mirror
-  `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`. `down_revision` will be
-  set to the current head automatically.
+### 6.2 Migration
+`alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
 
-### 5.3 `db/worklog.py`
-Mirror `db/notes.py`. Functions:
-
+### 6.3 `db/worklog.py` (mirror `db/notes.py`)
 ```python
-def create_worklog(transcript, log_date, created_by, entries) -> dict
-# entries: list of {case_id|None, minutes, description, raw_reference, person_ids: [int]}
-# Creates the VoiceLog + all WorklogEntry rows + people junction rows in ONE transaction.
+def get_worklog_candidates(log_date, user_id) -> dict
+# Returns {"events":[...], "tasks":[...], "comments":[...]} for log_date,
+# scoped to the user's cases (case.attorney_ids/paralegal_ids contains user_id; fall back to all).
+# Each candidate: {source_type, source_id, case_id, case_name, short_name, description,
+#                  anchored_minutes|None, when}. anchored_minutes derived from event time/end_date.
+# events: db.events filtered date==log_date. tasks: completion_date==log_date (and/or
+# updated_at::date==log_date with status terminal). comments: user-authored (NON-is_system)
+# case_comments created on log_date — each is a candidate work item (refine filter per §4).
 
-def get_worklog_by_case(case_id) -> dict
-# Returns entries for a case, newest first, grouped/orderable by activity_date,
-# each with its people (id+name) and a total-minutes summary.
+def create_worklog_draft(transcript, log_date, created_by, entries) -> dict
+# Creates VoiceLog(status='draft') + WorklogEntry rows + people junction, ONE transaction.
+# entries: [{case_id|None, minutes, description, raw_reference, source_type, source_id, person_ids}]
 
-def get_worklog_by_person(person_id) -> dict
-# Returns entries that name this person, newest first, each with its case (id+name).
-
-def delete_worklog_entry(entry_id) -> bool
-def update_worklog_entry(entry_id, **fields) -> dict | None  # edit minutes/description/case_id/people post-hoc
+def get_worklog_draft(voice_log_id) -> dict | None        # for deferred confirmation
+def list_worklog_drafts(user_id) -> list                  # "needs review"
+def confirm_worklog(voice_log_id, entries) -> dict        # apply edits, status='confirmed', confirmed_at=now
+def get_worklog_by_case(case_id) -> dict                  # confirmed only; entries + total minutes, grouped by date
+def get_worklog_by_person(person_id) -> dict              # confirmed only; entries + case info
+def update_worklog_entry(entry_id, **fields) -> dict|None # post-hoc edit (optional)
+def delete_worklog_entry(entry_id) -> bool                # optional
+def delete_worklog_draft(voice_log_id) -> bool            # discard an abandoned draft
 ```
+`get_worklog_by_case`/`by_person` must filter to `voice_logs.status == 'confirmed'`.
+Eager-load people + case names (`selectinload`/joins) to avoid N+1. Export in `db/__init__.py`.
 
-Use `SessionLocal()` context manager, `flush()/refresh()` before building the dict,
-`commit()` last. Add `_entry_to_dict()` using `WorklogEntryOut`. Eager-load people and
-case names with `selectinload`/joins to avoid N+1.
-
-Export all functions in `db/__init__.py` (import block + `__all__`).
-
-### 5.4 `services/worklog_extractor.py`
-A near-twin of `services/case_extractor.py`. Responsibilities:
-
-1. Accept the raw `transcript`, the `log_date`, and **candidate context**: a compact list
-   of the firm's active cases (`id`, `case_name`, `short_name`) and contacts
-   (`id`, `name`, `organization`). Pull these via existing `db` queries (e.g. a light
-   case list + `db.persons` list). Keep the lists lean (id + name) to control tokens;
-   prompt-cache them if they get large (see `services/chat/client.py` for the
-   `cache_control` pattern).
-2. Call Claude (`settings.extraction_model`) with a **single forced tool** —
-   `submit_worklog` — whose input schema is a list of entries:
+### 6.4 `services/worklog_consolidator.py` (near-twin of `services/case_extractor.py`)
+Inputs: `transcript`, `log_date`, the **selected surfaced items** (resolved to their
+descriptions/anchored durations), and **candidate cases/contacts** (id + name; lean;
+prompt-cache if large). Single forced tool `submit_worklog`:
 
 ```python
 SUBMIT_WORKLOG_TOOL = {
-    "name": "submit_worklog",
-    "description": "Submit the structured work-log entries extracted from the memo.",
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "entries": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "description": {"type": "string", "description": "Concise summary of the work done."},
-                        "minutes": {"type": "integer", "description": "Estimated duration in minutes."},
-                        "case_id": {"type": ["integer", "null"], "description": "ID of the matched case, or null if no confident match."},
-                        "case_guess": {"type": "string", "description": "The case name as the user referred to it (for display when unmatched)."},
-                        "person_ids": {"type": "array", "items": {"type": "integer"}, "description": "IDs of matched people mentioned in this activity."},
-                        "raw_reference": {"type": "string", "description": "The original phrase from the memo this entry came from."}
-                    },
-                    "required": ["description", "minutes", "raw_reference"]
-                }
-            }
-        },
-        "required": ["entries"]
-    }
+  "name": "submit_worklog",
+  "description": "Submit the consolidated work-log entries.",
+  "input_schema": {"type":"object","properties":{"entries":{"type":"array","items":{
+    "type":"object","properties":{
+      "description":{"type":"string"},
+      "minutes":{"type":"integer"},
+      "case_id":{"type":["integer","null"]},
+      "case_guess":{"type":"string","description":"How the user referred to the case (for unmatched display)."},
+      "person_ids":{"type":"array","items":{"type":"integer"}},
+      "source_type":{"type":"string","enum":["manual","event","task","comment"]},
+      "source_id":{"type":["integer","null"]},
+      "raw_reference":{"type":"string"}
+    },"required":["description","minutes","source_type","raw_reference"]}}},
+    "required":["entries"]}
 }
 ```
+`tool_choice={"type":"tool","name":"submit_worklog"}`; read `block.input["entries"]`;
+`record_usage_from_message(source="worklog_consolidator", request_type="consolidate", ...)`.
+**Does not persist** — returns entries to the route.
 
-3. Use `tool_choice={"type": "tool", "name": "submit_worklog"}`, read `block.input["entries"]`.
-4. `record_usage_from_message(source="worklog_extractor", request_type="parse_worklog", model=..., message=message)`.
-5. Return the entries list (the route hands it to the frontend for review; it is NOT
-   saved yet).
-
-**System prompt must encode the philosophy and the two-pass logic.** Sketch:
-
+**System prompt** must encode the philosophy, the surfaced-item handling, the two-pass
+logic, AI task-duration estimation, and the day budget:
 ```
-You convert a lawyer's informal end-of-day memo into discrete work-log entries.
+You convert a lawyer's day into discrete work-log entries.
 
-STEP 1 — SPLIT: Break the memo into separate activities. Each activity is a distinct
-piece of work tied to a single case. "Drafted discovery for Armstrong, then a call
-with Tanner about Reyes, then back to the Armstrong opposition" = THREE activities.
+INPUTS:
+- Selected items already on record (events, completed tasks, case comments), each with a
+  case, a description, and sometimes an anchored duration. A comment represents work that
+  took time (a call, a review, a follow-up) — treat it as a real activity.
+- A free-text memo of everything else.
+- Candidate cases and contacts to match against.
 
-STEP 2 — ESTIMATE TIME (treat the day as a budget): Assign each activity a duration in
-minutes using context. Rules of thumb:
-  - A phone call / quick call with no stated length ≈ 30 minutes.
-  - "Spent the morning / the afternoon on X" ≈ 210–240 minutes IF nothing else competes
-    for that block; if the morning contains several activities, divide the block among
-    them sensibly.
-  - A short task ("sent an email", "reviewed a doc") ≈ 10–20 minutes.
-  - Never inflate. If duration is truly unknowable and there's no anchor, estimate
-    conservatively. Do NOT ask the user for clarification — just estimate.
-  - Do not let the day's total exceed what the memo implies (don't fill the morning AND
-    log a separate 3-hour morning call).
+STEP 1 — SPLIT the memo into separate activities (one activity = one case). Merge each
+selected item in as its own activity, carrying its source_type/source_id and case.
 
-STEP 3 — MATCH: For each activity, match the case to the provided case list by name
-(fuzzy is fine — "Armstrong" → the case whose name contains Armstrong). Match named
-people to the contact list. If you cannot confidently match a case, set case_id=null
-and put the user's phrasing in case_guess. Same for people (omit unmatched). ALWAYS
-fill raw_reference with the original phrase.
+STEP 2 — ESTIMATE DURATIONS:
+- Events with a real start/end time keep that length (anchored).
+- A comment/call with no stated length ≈ 30 min (longer if the text implies more).
+- TASKS: estimate from the task description and typical legal effort (a quick filing vs.
+  drafting a brief). Use judgment; do NOT use one rigid number.
+- Free-text work: estimate from cues ("spent the morning" = a substantial block).
 
-Use the submit_worklog tool. Provide entries in the order they occurred.
+STEP 3 — FIT THE DAY: The total across ALL entries must read like a realistic working day,
+roughly 5–7 hours, and MUST NOT exceed 7 hours (420 minutes). Anchored items keep their
+lengths; flexible work (tasks, "the morning") absorbs the remainder and is scaled to fit.
+If anchored items alone exceed 7h, keep them accurate and let the total exceed — the user
+will adjust. Never pad with invented activities; only distribute time across what's given.
+
+STEP 4 — MATCH each activity to a case (fuzzy by name) and to people from the candidate
+lists. If no confident case match: case_id=null, put the user's phrasing in case_guess.
+Set source_type='manual', source_id=null for free-text-only entries. ALWAYS fill raw_reference.
+
+Use the submit_worklog tool; entries in chronological order.
 ```
 
-> **Matching note:** The model does the matching from the supplied lists. As a
-> belt-and-suspenders improvement (optional), the route can run any `case_id=null`
-> entries through the existing `db.fuzzy_search_persons_db` / case search to offer a
-> best-guess in the review UI. Not required for v1.
-
-### 5.5 `schemas/inputs.py` and `schemas/outputs.py`
+### 6.5 `schemas/inputs.py` / `schemas/outputs.py`
 **Inputs:**
 ```python
+class WorklogSelectionInput(BaseModel):
+    source_type: Literal["event","task","comment"]
+    source_id: int
+
+class ConsolidateWorklogInput(BaseModel):
+    transcript: str = ""
+    log_date: Optional[str] = None          # YYYY-MM-DD; defaults today
+    selections: list[WorklogSelectionInput] = []
+
 class WorklogEntryInput(BaseModel):
     case_id: Optional[int] = None
     minutes: int
     description: str
     raw_reference: Optional[str] = None
+    source_type: Optional[str] = "manual"
+    source_id: Optional[int] = None
     person_ids: list[int] = []
 
-class ParseWorklogInput(BaseModel):
-    transcript: str
-    log_date: Optional[str] = None  # YYYY-MM-DD; defaults to today server-side
-
-class SaveWorklogInput(BaseModel):
-    transcript: str
+class ConfirmWorklogInput(BaseModel):           # used by confirm + "save draft"
+    voice_log_id: Optional[int] = None
+    transcript: str = ""
     log_date: Optional[str] = None
     entries: list[WorklogEntryInput]
 ```
-**Outputs:** `WorklogEntryOut` (`from_attributes=True`: id, case_id, minutes, description,
-raw_reference, activity_date, created_at, plus nested `people: list[{id,name}]` and
-optional `case_name`/`short_name`). A `ParsedWorklogEntryOut` for the parse response
-(includes `case_guess`). Mirror `NoteOut`. No `__all__` needed — re-exported by `import *`.
+**Outputs:** `WorklogCandidateOut`, `WorklogEntryOut` (id, case_id, case_name, short_name,
+minutes, description, raw_reference, activity_date, source_type, source_id, created_at,
+`people: list[{id,name}]`), `ParsedWorklogEntryOut` (adds `case_guess`),
+`WorklogDraftOut` (voice_log + entries). `from_attributes=True`; no `__all__` needed.
 
-### 5.6 `routes/worklog.py` → `register_worklog_routes(mcp)`
-Mirror `routes/notes.py`. Endpoints (all `auth.require_auth`, all DB calls via
-`asyncio.to_thread`):
+### 6.6 `routes/worklog.py` → `register_worklog_routes(mcp)` (mirror `routes/notes.py`)
+All `auth.require_auth`; DB via `asyncio.to_thread`; `created_by` from `auth.get_current_user`.
 
-| Method | Path | Purpose |
-|---|---|---|
-| POST | `/api/v1/worklog/parse` | Body `ParseWorklogInput`. Calls the extractor, returns parsed entries (NOT saved). |
-| POST | `/api/v1/worklog` | Body `SaveWorklogInput`. Persists via `db.create_worklog`. Returns the saved rows. |
-| GET | `/api/v1/worklog/by-case/{case_id}` | Entries + total minutes for a case. |
-| GET | `/api/v1/worklog/by-person/{person_id}` | Entries for a contact. |
-| PATCH | `/api/v1/worklog/entries/{entry_id}` | Edit an entry post-hoc (optional v1.1). |
-| DELETE | `/api/v1/worklog/entries/{entry_id}` | Delete an entry (optional v1.1). |
+| Method | Path | Phase | Purpose |
+|---|---|---|---|
+| GET | `/api/v1/worklog/candidates?date=YYYY-MM-DD` | 1 | Surfaced items for the date (events/tasks/comments), scoped to the user. |
+| POST | `/api/v1/worklog/consolidate` | 2 | Body `ConsolidateWorklogInput`. Resolves selections, runs the consolidator, **saves a draft**, returns `WorklogDraftOut`. |
+| GET | `/api/v1/worklog/drafts` | 3 | List pending drafts ("needs review"). |
+| GET | `/api/v1/worklog/{voice_log_id}` | 3 | Fetch one draft for deferred confirmation. |
+| POST | `/api/v1/worklog/{voice_log_id}/confirm` | 3 | Body `ConfirmWorklogInput`. Apply edits, set `confirmed`. |
+| DELETE | `/api/v1/worklog/{voice_log_id}` | 3 | Discard an abandoned draft. |
+| GET | `/api/v1/worklog/by-case/{case_id}` | view | Confirmed entries + total for a case. |
+| GET | `/api/v1/worklog/by-person/{person_id}` | view | Confirmed entries for a contact. |
+| PATCH/DELETE | `/api/v1/worklog/entries/{entry_id}` | view | Post-hoc edit/delete (optional v1.1). |
 
-Get the current user via `auth.get_current_user(request)` for `created_by`. Register in
-`routes/__init__.py` **before** the static block; add to `__all__`.
+Register in `routes/__init__.py` **before** the static block; add to `__all__`.
 
-### 5.7 MCP tool (secondary — include if time allows)
-Add `log_work` to `tools.py` so the user can also log via Claude chat. Keep it **thin**:
-accept already-structured entries (Claude resolves cases/people itself using the existing
-`search` tool, exactly like `import_case` does) and call `db.create_worklog`. Then:
-- Add an input model `LogWorkInput` to `schemas/inputs.py`.
-- Document it in `MCP_INSTRUCTIONS` (`main.py`, tools-overview section ~lines 30–41) —
-  this string is hand-maintained and required.
+### 6.7 MCP tool (secondary — include if time allows)
+Add `log_work` to `tools.py`: accept already-structured entries (Claude resolves
+cases/people via the existing `search` tool, like `import_case` does) → `db.create_worklog_draft`
+(or directly confirmed). Add `LogWorkInput` to `schemas/inputs.py`. **Document it in
+`MCP_INSTRUCTIONS`** (hand-maintained).
 
-### 5.8 Dockerfile
-**No change needed.** All new files land in already-copied directories (`db/`, `routes/`,
-`services/`, `schemas/`). (Only update the Dockerfile if you add a brand-new top-level
-file or directory.)
+### 6.8 Dockerfile
+**No change needed** — all files land in already-copied dirs (`db/`, `routes/`,
+`services/`, `schemas/`).
 
 ---
 
-## 6. Frontend Implementation
+## 7. Frontend Implementation
 
-Repeatable order (per CLAUDE.md): **types → service → components → page → wire-in.**
+Order: **types → service → components → page → wire-in.**
 
-### 6.1 Types — `frontend/src/types/worklog.ts`
-```ts
-export interface WorklogEntry {
-  id: number
-  case_id: number | null
-  case_name: string | null
-  short_name: string | null
-  minutes: number
-  description: string
-  raw_reference: string | null
-  activity_date: string
-  created_at: string
-  people: { id: number; name: string }[]
-}
-export interface ParsedWorklogEntry {
-  description: string
-  minutes: number
-  case_id: number | null
-  case_guess: string | null
-  person_ids: number[]
-  people: { id: number; name: string }[]
-  raw_reference: string
-}
-```
+### 7.1 Types — `frontend/src/types/worklog.ts`
+`WorklogCandidate` (source_type, source_id, case_id, case_name, description,
+anchored_minutes, when), `WorklogEntry`, `ParsedWorklogEntry` (+ case_guess),
+`WorklogDraft` (voice_log fields + entries[]).
 
-### 6.2 Service — `frontend/src/services/worklog.ts`
-Mirror `services/cases.ts` (`apiFetch` from `@/lib/api`). Functions:
-`parseWorklog(transcript, logDate)`, `saveWorklog(payload)`,
-`getWorklogByCase(caseId)`, `getWorklogByPerson(personId)`, and (optional)
-`updateWorklogEntry`, `deleteWorklogEntry`.
+### 7.2 Service — `frontend/src/services/worklog.ts` (mirror `services/cases.ts`)
+`getWorklogCandidates(date)`, `consolidateWorklog(payload)`, `listWorklogDrafts()`,
+`getWorklogDraft(id)`, `confirmWorklog(id, payload)`, `discardWorklogDraft(id)`,
+`getWorklogByCase(caseId)`, `getWorklogByPerson(personId)`.
 
-### 6.3 Page — `frontend/src/pages/worklog/index.tsx` (+ `components/`)
-A dedicated page (co-located feature module). Flow:
-1. **Compose:** a large `<Textarea>` + a date picker (defaults to today). A "Parse"
-   button. (Add a small hint that they can dictate with their phone keyboard's mic.)
-2. On Parse → `useMutation(parseWorklog)`; show a loading state.
-3. **Review:** render the parsed entries as an **editable list**
-   (`components/worklog-review.tsx`):
-   - Each row: editable description, a `minutes` input (or quick chips: 15/30/60/90/morning),
-     a **case combobox** (searchable, prefilled with the match; shows `case_guess` as a
-     warning chip when `case_id` is null), and a **people multi-select**.
-   - Running **total for the day** displayed at the top.
-   - Use shadcn `Command`/`Combobox`, `Input`, `Badge`, `Button`. Check exact APIs via the
-     shadcn MCP. **Square corners**, Hugeicons, semantic tokens.
-4. **Save:** `useMutation(saveWorklog)` → on success, clear/redirect and invalidate any
-   relevant queries. Toast confirmation.
+### 7.3 Page — `frontend/src/pages/worklog/index.tsx` (+ `components/`)
+Three-phase stepper:
+1. **Input** (`worklog-input.tsx`): date picker (defaults today) → `getWorklogCandidates`
+   → render grouped multi-select (Events / Completed Tasks / Comments), each row showing
+   case + description + suggested time, checkbox to include. Plus a `<Textarea>` for
+   free-form. "Consolidate" button.
+2. **Consolidate:** `useMutation(consolidateWorklog)` with selections + transcript →
+   returns a draft → advance to review. Loading state.
+3. **Confirm** (`worklog-review.tsx`): editable list — description, `minutes` input (or
+   quick chips), searchable **case combobox** (warning chip when `case_id` null, shows
+   `case_guess`), **people multi-select**. **Running day total** at top with a subtle
+   over-7h warning. Buttons: **Confirm** (`confirmWorklog`) and **Save for later** (keeps
+   it a draft). Don't gate saving on required fields.
 
-Keep mislink-fixing to a **single glance** — do not gate saving behind required fields
-(unmatched entries save fine with `case_id = null`).
+Also surface a **"Drafts to review"** entry (badge/list via `listWorklogDrafts`) so a
+deferred draft can be reopened into the review step.
 
-### 6.4 Case detail card — `frontend/src/pages/cases/components/case-work-log.tsx`
-`useQuery(["worklog-by-case", caseId], () => getWorklogByCase(caseId))`. Render entries
-grouped by `activity_date` (use the existing `frontend/src/lib/datetime.ts` helpers —
-`formatDateHeader`, `getDateKey`), each showing description, minutes, and people chips;
-show a **total time** for the case at the card header. Mount it in
-`frontend/src/pages/cases/detail.tsx` near `<CaseActivityFeed />` (~line 315).
-Recommendation: **always-on** (don't gate behind `feature_toggles`).
+shadcn: `Command`/Combobox, `Checkbox`, `Input`, `Badge`, `Textarea`, `Button`, `Tabs` or a
+stepper. **Square corners, Hugeicons, semantic tokens, `@/` imports.** Verify component
+APIs via the shadcn MCP.
 
-### 6.5 Contact "Interactions" section — in `contact-detail-dialog.tsx`
-Add a section (`useQuery(["worklog-by-person", personId], ...)`) listing the activities
-that named this person, by date, each linking to its case. Place it alongside the
-existing SMS / roles sections.
+### 7.4 Case detail card — `frontend/src/pages/cases/components/case-work-log.tsx`
+`useQuery(["worklog-by-case", caseId], () => getWorklogByCase(caseId))`; group by
+`activity_date` (use `lib/datetime.ts`); show description, minutes, people chips,
+source-type icon, and a **case time total** in the header. Mount in `detail.tsx` near
+`<CaseActivityFeed/>`. Recommend **always-on** (not `feature_toggles`-gated).
 
-### 6.6 Wire-in (locate these files first)
-- **Router:** add a `/log` route pointing at `pages/worklog/index.tsx` (React Router v7 —
-  find the route table, likely `App.tsx` or a dedicated router file).
-- **Header/nav:** add a global "Log my day" button (Hugeicons mic/pencil icon) in the app
-  header/sidebar (`frontend/src/components/layout/`). It navigates to `/log`.
+### 7.5 Contact "Interactions" section — in `contact-detail-dialog.tsx`
+`useQuery(["worklog-by-person", personId], ...)`; list activities naming this person, by
+date, each linking to its case. Place near the SMS / roles sections.
+
+### 7.6 Wire-in (locate first)
+- **Router:** add `/log` → `pages/worklog/index.tsx` (React Router v7 route table).
+- **Header/nav:** global "Log my day" button (Hugeicons mic/pencil) in
+  `components/layout/` → navigates to `/log`. Consider a small badge when drafts await review.
 
 ---
 
-## 7. Build Sequence (recommended order)
+## 8. Build Sequence
 
-1. `models.py` → add the three models (+ relationships).
+1. `models.py` (+ `Case` relationship).
 2. `alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
-3. `schemas/inputs.py` + `schemas/outputs.py` → add the models.
-4. `db/worklog.py` → CRUD/queries; export in `db/__init__.py`.
-5. `services/worklog_extractor.py` → the LLM parse.
-6. `routes/worklog.py` → endpoints; register in `routes/__init__.py` (before static).
-7. (Optional) `tools.py` `log_work` + `MCP_INSTRUCTIONS` in `main.py`.
-8. Restart backend with `/dev`; smoke-test the API with `curl` (parse → save → by-case → by-person).
-9. Frontend: types → service → review component → page → case card → contact section → router + header.
+3. `schemas/inputs.py` + `schemas/outputs.py`.
+4. `db/worklog.py` → candidates, draft create, confirm, by-case/person; export in `db/__init__.py`.
+5. `services/worklog_consolidator.py`.
+6. `routes/worklog.py` → register in `routes/__init__.py` (before static).
+7. (Optional) `tools.py` `log_work` + `MCP_INSTRUCTIONS`.
+8. Restart with `/dev`; smoke-test with `curl`: candidates → consolidate (draft) → confirm
+   → by-case → by-person; verify drafts list + deferred confirm.
+9. Frontend: types → service → input + review components → page (stepper + drafts) → case
+   card → contact section → router + header.
 10. `cd frontend && npm run type-check && npm run build`; visual pass via `/dev`.
 
 ---
 
-## 8. Verification Checklist
+## 9. Verification Checklist
 
 **Backend**
-- [ ] `alembic upgrade head` applies cleanly; `alembic check` reports models in sync.
-- [ ] `POST /api/v1/worklog/parse` with a multi-case memo returns multiple entries with
-      sane minutes and correct case/person matches; an unknown case → `case_id null` +
-      `case_guess` populated.
-- [ ] `POST /api/v1/worklog` persists VoiceLog + entries + people junction in one txn.
-- [ ] `GET /api/v1/worklog/by-case/{id}` and `/by-person/{id}` return correct data + totals.
-- [ ] Token usage recorded (row in `token_usage_log` with `source='worklog_extractor'`).
-- [ ] Unauthed requests get 401 (auth dependency present on every route).
+- [ ] `alembic upgrade head` clean; `alembic check` in sync.
+- [ ] `GET /worklog/candidates?date=…` returns the right events/tasks/comments for the date
+      (non-`is_system` comments only), scoped to the user, with anchored durations on timed events.
+- [ ] `POST /worklog/consolidate` saves a **draft** and returns entries; total is ~5–7h and
+      **never > 7h** (unless anchored items alone exceed it); tasks get sensible AI estimates;
+      surfaced items carry `source_type`/`source_id`; unmatched case → `case_id null` + `case_guess`.
+- [ ] Drafts list + `GET /worklog/{id}` support **deferred** confirmation.
+- [ ] `POST /worklog/{id}/confirm` flips status to `confirmed`, applies edits.
+- [ ] `by-case` / `by-person` return **confirmed-only** data with correct totals.
+- [ ] Token usage row written (`source='worklog_consolidator'`). Unauthed → 401.
 
 **Frontend**
-- [ ] `npm run type-check` and `npm run build` pass.
-- [ ] `/log` page: type a memo → Parse → editable review → fix a mislink → Save → toast.
-- [ ] Case detail shows the Work Log card with grouped-by-day entries and a total.
-- [ ] Contact dialog shows the Interactions section.
-- [ ] Square corners, Hugeicons, semantic color tokens, `@/` imports throughout.
+- [ ] `npm run type-check` + `npm run build` pass.
+- [ ] Phase 1: candidates render as multi-select + free-text works.
+- [ ] Phase 2 → Phase 3: editable review with running total + over-7h warning.
+- [ ] "Save for later" persists a draft; reopening from the drafts list lands back in review.
+- [ ] Case card (grouped by day, total) + contact Interactions section render.
+- [ ] Square corners, Hugeicons, semantic tokens, `@/` imports.
 
-**Behavioral (the philosophy)**
-- [ ] "Had a call with X" with no duration → ~30 min, no prompt for clarification.
-- [ ] "Spent the morning on Y" (sole morning item) → ~3.5–4 hrs.
-- [ ] A memo mixing several cases fans out correctly; the day isn't double-counted.
-
----
-
-## 9. Open Decisions for the Implementer
-
-1. **Active-case scope for matching context.** Pull *all* non-closed cases, or only the
-   logged-in user's cases (`attorney_ids`/`paralegal_ids`)? Recommendation: the user's
-   cases first; fall back to all if the count is small. Keep the candidate list lean to
-   control tokens (prompt-cache it if large).
-2. **Editing/deleting entries after save** (PATCH/DELETE endpoints + UI) — listed as
-   optional v1.1. Decide whether to ship in v1.
-3. **MCP `log_work` tool** — secondary. Ship if time allows; it makes logging-via-Claude
-   possible and fits the MCP-first architecture.
-4. **`minutes` display format** — store integer minutes; render as "1h 30m" / "30m" via a
-   small formatter in `frontend/src/lib/`.
-5. **Multi-user.** `created_by` is captured. Decide whether case/contact views show
-   everyone's entries or filter to the current user (the firm is small; default to
-   showing all, label with initials if needed).
+**Behavioral**
+- [ ] Selecting a deposition event + typing "drafted the Reyes brief" yields two entries; the
+      day totals to a believable ≤7h.
+- [ ] No clarifying questions are ever asked; durations are estimated silently.
+- [ ] A selected item already logged once does not re-surface on a later visit.
 
 ---
 
-## 10. Guardrails (from CLAUDE.md — don't trip these)
+## 10. Open Decisions for the Implementer
 
-- **UTC in the DB**, Pacific for display. `DateTime(timezone=True)` everywhere;
-  `datetime.now(timezone.utc)`/`func.now()` for writes; never bare `datetime.now()`.
+1. **7-hour rule: hard vs soft.** Plan treats it as a target band (5–7h) with a 7h ceiling
+   the AI won't cross, **except** when anchored events legitimately exceed it (then keep
+   them accurate). The user can always override durations in confirmation. Confirm this is desired.
+2. **"Done today" task filter.** `completion_date == log_date` only, or also
+   `updated_at::date == log_date` for partially-done/status-changed tasks? (Plan: both,
+   labeled.)
+3. **Comment candidates.** Surface all user-authored (non-`is_system`) `case_comments` for
+   the date as work candidates (a comment generally reflects time spent). `is_system` audit
+   lines are excluded. Decide whether to also include the polymorphic `comments` table, and
+   whether any further filtering is wanted.
+4. **Active-case scope for matching.** User's cases first (via `attorney_ids`/`paralegal_ids`),
+   fall back to all when small. Keep candidate lists lean; prompt-cache if large.
+5. **Draft housekeeping.** Auto-expire/clean abandoned drafts? (Plan: provide a delete; no auto-expiry v1.)
+6. **MCP `log_work` tool** — ship in v1 or defer.
+7. **`minutes` display** — store integer minutes; render "1h 30m" via a `lib/` formatter.
+8. **Multi-user views** — show all firm entries or filter to current user? (Small firm:
+   default to all, label with initials.)
+
+---
+
+## 11. Guardrails (from CLAUDE.md)
+
+- **UTC in DB**, Pacific for display. `DateTime(timezone=True)`; `func.now()` /
+  `datetime.now(timezone.utc)`; never bare `datetime.now()`.
 - **Route order:** new routes before `register_static_routes` (SPA catch-all is last).
-- **MCP_INSTRUCTIONS** is hand-maintained — update it if you add the MCP tool.
-- **Production runs `-w 1`** — irrelevant here (no in-memory state added), just don't
-  change it.
+- **`MCP_INSTRUCTIONS`** is hand-maintained — update if you add the MCP tool.
+- **`-w 1`** stays (no shared in-memory state added here).
 - **Square corners**, **Hugeicons** (not Lucide), **`@/` imports**, **kebab-case files**,
-  semantic color tokens. Use the **shadcn MCP** + **Context7** to confirm component APIs
-  before writing UI.
-- Never push to `main`; this work stays on `claude/voice-log-case-contact-Qgp6Y`.
+  semantic color tokens. Use the **shadcn MCP** + **Context7** before writing UI.
+- Never push to `main`; stay on `claude/voice-log-case-contact-Qgp6Y`.

--- a/docs/plans/worklog-feature-plan.md
+++ b/docs/plans/worklog-feature-plan.md
@@ -16,9 +16,11 @@ about the Reyes matter, then drafted discovery for Armstrong again."* — and ha
 turned into discrete, time-estimated **work-log entries** linked to cases (and people).
 
 Crucially, **the system already knows about a lot of the day's work** — calendared
-events (depositions, hearings), tasks completed/updated that day, and calls logged in the
-activity feed. So instead of making the user re-describe those, the system **surfaces
-them for one-tap selection**. The user only free-types what *isn't* already captured.
+events (depositions, hearings), tasks completed/updated that day, and case comments in
+the activity feed (a comment usually reflects something that took time). So instead of
+making the user re-describe those, the system **surfaces them for one-tap selection**, and
+the AI **merges** that context together with the free-text into a single day's log. The
+user only free-types what *isn't* already captured.
 
 Later, the user can open a **case** and see everything they did on it, by day, with a
 rough time total — and open a **contact** and see every interaction with that person.
@@ -28,49 +30,56 @@ rough time total — and open a **contact** and see every interaction with that 
 - **This is NOT a time tracker.** No start/stop, no 10:00–11:00 precision. The goal is
   *broad strokes* — a low-effort habit that yields a rough sense of effort per case.
 - **Never make the user re-describe what's already in the system.** Surface it; let them
-  select it.
+  select it; the AI folds it in.
 - **No nitpicky follow-up questions.** The AI estimates durations from context. It never
   interrogates.
 - **A realistic day, capped.** The AI consolidates everything into a believable **5–7
   working-hour day** and **never exceeds ~7 hours** total. It estimates task durations
   itself rather than using rigid per-item defaults.
+- **Merge, don't link.** Surfaced items are just *context* the AI smashes into the
+  unified work-log format. We do **not** keep references back to the source rows — the
+  consolidated entry stands on its own. (This is a deliberate simplification.)
 
 ---
 
 ## 2. The Three-Phase Flow (the core UX — resolved with the user)
 
-The `/log` page walks through three phases. **Phase 3 can happen immediately after Phase
-2, or be deferred to later** — so the consolidated result is **persisted as a draft** and
-remains confirmable later.
+The `/log` page walks through three phases. **Phase 2 runs asynchronously** and **Phase 3
+can happen later** — so the user can fire off the consolidation, walk away, and come back
+to review when it's ready.
 
 ### Phase 1 — Input
 Two lanes that merge:
 - **Surfaced items (multi-select):** a pre-built list of things already on record for the
-  selected date — **events**, **completed/updated tasks**, and **case comments / activity-feed
-  items** (calls *and* any other logged work — a comment usually reflects something that took
-  time). Each is pre-filled with its case and description. The user just ticks the ones that
-  represent real work-time.
+  selected date — **events**, **completed/updated tasks**, and **case comments** (calls
+  *and* any other logged work — a comment usually reflects something that took time). Each
+  is pre-filled with its case and description. The user just ticks the ones that represent
+  real work-time.
 - **Free-form writing:** a textarea for everything not already captured.
 
-### Phase 2 — Consolidation (AI)
-The AI receives the **selected surfaced items + the free-text memo + candidate
-cases/contacts**, and in a single call:
+### Phase 2 — Consolidation (AI, **asynchronous**)
+On submit, the server **creates a `voice_log` with `status='processing'`, returns
+immediately, and runs the AI in a background thread.** The UI shows a "working on it — come
+back later" state; the user can navigate away. The background job:
 1. **Splits** the memo into discrete activities (one activity = one case).
-2. **Estimates durations** — including estimating **task** durations from their
-   descriptions (not fixed defaults). Events with a real start/end time keep their actual
-   length.
-3. **Apportions a realistic working day** — total lands in **~5–7 hours** and **never
+2. **Merges** the selected surfaced items into the same set of activities (smashing each
+   item's case + description into the unified format).
+3. **Estimates durations** — including estimating **task** durations from their
+   descriptions (not fixed defaults). Events with a real start/end time keep their length.
+4. **Apportions a realistic working day** — total lands in **~5–7 hours** and **never
    exceeds 7 hours (420 min)**.
-4. **Matches** each activity to a case and to people from the candidate lists; unmatched →
-   `case_id = null` with the raw phrasing preserved.
+5. **Matches** each activity to a case and to people; unmatched → `case_id=null` with the
+   raw phrasing preserved.
+6. Writes the entries and flips the log to **`status='ready'`** (or `'failed'` on error).
 
-The result is **saved as a draft** (`voice_logs.status = 'draft'`) and returned for review.
+This mirrors the existing intake AI pattern (see §4) and works under `-w 1` because it's
+in-process.
 
-### Phase 3 — Confirmation
-A **one-glance, editable** review: the user confirms/fixes case links, people, and
-durations, then confirms. On confirm, the draft flips to `confirmed`. **Drafts not
-confirmed remain in a "needs review" list** so confirmation can happen later. Only
-**confirmed** entries count toward case/contact totals.
+### Phase 3 — Confirmation (now or later)
+A **one-glance, editable** review of a `ready` log: the user confirms/fixes case links,
+people, and durations, then confirms. On confirm, status flips to **`confirmed`**.
+**Processing/ready logs live in a "needs review" list** so the user can come back anytime.
+Only **confirmed** entries count toward case/contact totals.
 
 ---
 
@@ -82,13 +91,14 @@ confirmed remain in a "needs review" list** so confirmation can happen later. On
 | Activity ↔ case | **Each activity belongs to exactly one case** (or none → unmatched). |
 | Time granularity | **Per-activity** `minutes`. Each entry has its own duration. |
 | Activity ↔ people | **Many-to-many.** One activity can name several people. |
-| Unknown names | **Preserve raw text, leave unlinked** (`case_id = null`, keep `raw_reference`/`case_guess`). |
-| Surfaced items | **Multi-select** from events, completed/updated tasks, and case comments (activity-feed items) for the date — a comment usually reflects work that took time. Don't make the user re-describe them. |
-| Link vs copy | **Link, don't copy.** A selected item becomes an entry that *references* its source via `source_type` + `source_id` (no duplication, no drift, no re-surfacing). Free-typed entries are `source_type = 'manual'`. |
-| Time estimation | **AI estimates** (incl. task durations). Two-pass: split → estimate/apportion → match. |
+| Unknown names | **Preserve raw text, leave unlinked** (`case_id=null`, keep `raw_reference`/`case_guess`). |
+| Surfaced items | **Multi-select** from events, completed/updated tasks, and case comments for the date. Don't make the user re-describe them. |
+| **Merge, don't link** | Surfaced items are **context only**. The AI smashes them into the unified work-log format. **No `source_type`/`source_id` back-references** — keeps the model and UI simple. |
+| Time estimation | **AI estimates** (incl. task durations). Two-pass: split/merge → estimate/apportion → match. |
 | Day budget | **Target ~5–7 hrs; hard ceiling ~7 hrs.** Anchored items (events with real times) keep their length; flexible work absorbs the remainder. |
+| **Async consolidation** | **Phase 2 runs in a background thread.** Create the log as `processing`, return immediately, show "working on it," flip to `ready` when done. Mirror the intake AI pattern. |
 | Review | **One-glance, editable, non-blocking.** Unmatched entries still save fine. |
-| Deferred confirm | **Consolidation persists a draft**; confirmation can happen now or later. Only confirmed entries count. |
+| Deferred confirm | **The log persists** through `processing → ready → confirmed`; confirmation can happen later. Only `confirmed` entries count. |
 | Audio | **Do NOT store audio.** Text only (phone dictation / paste). |
 | Entry point | **Dedicated `/log` page + a global button in the app header.** |
 | Naming | Domain = **`worklog`**. **Do NOT use `activity`** — already taken (see §4). |
@@ -102,78 +112,93 @@ confirmed remain in a "needs review" list** so confirmation can happen later. On
 **page-view analytics**. The frontend `CaseActivityFeed` is a **comment/system-event
 feed** backed by `case_comments`. **Keep the new feature in a `worklog` namespace.**
 
+### Async AI pattern to mirror (verified — this is exactly how Phase 2 should work)
+- **Trigger:** `routes/intakes.py` ~282 —
+  `threading.Thread(target=run_background_analysis, args=(intake_id,), daemon=True).start()`
+  after the route has created/updated the row, then returns its JSON response immediately.
+- **Worker:** `services/intake_ai.py:run_background_analysis(intake_id)` — calls
+  `db.set_ai_analyzing(intake_id, True)`, broadcasts, does the LLM work with its own
+  `SessionLocal()`, then `db.save_ai_analysis(...)` which writes results **and clears the
+  flag** (`ai_analyzing=False`). Wrapped so the flag is always cleared on error.
+- **Flag/state:** `db/intakes.py:set_ai_analyzing()` / `save_ai_analysis()` (`models.py`
+  `Intake.ai_analyzing` boolean).
+- **Push/poll:** the app has SSE — `broadcast({...})` (`routes/sse.py` /
+  `register_sse_routes`) pushes entity-changed events the frontend listens to; polling the
+  status also works.
+- **`-w 1` implication:** in-process threads are fine. A server restart mid-job would
+  leave `status='processing'` stuck (same limitation intakes have) — acceptable for v1; a
+  `'failed'` state + manual re-run covers the error path.
+
 ### Where the "surfaced item" sources live (verified)
-- **Events:** `events` table (`models.py` ~496). Filter by `date == log_date`. `event_type`,
-  `time`, `end_date`, `description`, `case_id`, `attendee_ids`. DB module: `db/events.py`.
+- **Events:** `events` table (`models.py` ~496). Filter `date == log_date`. `event_type`,
+  `time`, `end_date`, `description`, `case_id`. DB module: `db/events.py`.
 - **Tasks:** `tasks` table (`models.py` ~802). "Done today" = `completion_date == log_date`;
-  also consider `status` changes via `updated_at::date == log_date`. DB module: `db/tasks.py`.
-- **Case comments (the "comments" lane):** the activity feed is backed by `case_comments`
-  (`db/case_comments.py`) — and a polymorphic `comments` table exists too (`db/comments.py`,
-  `entity_type`/`entity_id`). **Treat user-authored (non-`is_system`) `case_comments` created
-  on `log_date` as candidate work items** — a comment usually reflects something that took the
-  user time (a call, a review, a follow-up). This is broader than "calls": any non-system
-  comment is a legitimate candidate. (Note: structured *interactions* currently exist only for
-  **intakes** — `intake_comments` with `detail={type:'interaction',...}` via
-  `services/interaction_summarizer.py`; cases have no structured interaction type yet, so the
-  generic comment is the right hook.) **Skip `is_system` comments** (they're auto-generated
-  audit lines like "X added a note", not work). **Confirm exact source at implementation time.**
+  also consider `updated_at::date == log_date` with a terminal status. DB module: `db/tasks.py`.
+- **Case comments:** the activity feed is `case_comments` (`db/case_comments.py`); a
+  polymorphic `comments` table also exists (`db/comments.py`, `entity_type`/`entity_id`).
+  **Surface user-authored (NON-`is_system`) `case_comments` created on `log_date`** — each
+  is a candidate work item. `is_system` rows are auto-generated audit lines ("X added a
+  note") and must be excluded. (Structured *interactions* exist only for **intakes** —
+  `intake_comments` with `detail={type:'interaction',...}`, `services/interaction_summarizer.py`
+  — not cases, so the generic non-system comment is the right hook.) **Confirm at impl time.**
 
 ### Current Alembic head
 - **Head: `d2cd156b344a`** (`alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`).
-  Single head, verified. Prefer `alembic revision --autogenerate` (you have a live DB),
-  which sets `down_revision` automatically. Re-verify with `alembic heads`.
+  Single head, verified. Prefer `alembic revision --autogenerate`; re-verify with `alembic heads`.
 
 ### Patterns to mirror (exact reference files)
 - **Migration:** `alembic/versions/d2cd156b344a_add_alert_dismissals_table.py`
 - **DB module:** `db/notes.py` — `SessionLocal()` ctx mgr, `_x_to_dict()` via the Out schema,
-  `flush()/refresh()/commit()` order. Exports in `db/__init__.py` (import block ~168 + `__all__` ~524).
+  `flush()/refresh()/commit()`. Exports in `db/__init__.py` (import block ~168 + `__all__` ~524).
 - **Routes:** `routes/notes.py` — `@mcp.custom_route(...)`, `auth.require_auth(request)`,
   `auth.get_current_user(request)`, `asyncio.to_thread(db.fn, ...)`, `pydantic_error(e)` /
   `api_error(...)` from `.common`. Register in `routes/__init__.py` **before**
   `register_static_routes(mcp)` (line 152); add to `__all__` (~156).
-- **Input schemas:** `schemas/inputs.py` — plain `BaseModel`, no `__all__` (re-exported by
-  `from .inputs import *`). **Output schemas:** `schemas/outputs.py` —
-  `ConfigDict(from_attributes=True)`; `model_dump(mode="json")` ISO-formats datetimes.
-  `NoteOut` (97–110) and `PersonOut` (357–369) are templates.
+- **Input schemas:** `schemas/inputs.py` (no `__all__`; re-exported by `import *`).
+  **Output schemas:** `schemas/outputs.py` — `ConfigDict(from_attributes=True)`;
+  `model_dump(mode="json")` ISO-formats datetimes. `NoteOut` (97–110), `PersonOut` (357–369).
 - **LLM extraction:** `services/case_extractor.py` — sync `anthropic.Anthropic`,
   `tool_choice={"type":"tool","name":...}` to FORCE structured output, read `block.input`,
   `db.token_usage.record_usage_from_message(source=..., request_type=..., model=..., message=...)`.
   Model = `settings.extraction_model` (`config.py`); key = `os.environ["ANTHROPIC_API_KEY"]`.
   Prompt-cache large candidate lists via the `cache_control` pattern in `services/chat/client.py`.
 - **MCP tool:** `tools.py` `manage_note` (~1292) — `@mcp.tool()`, helpers `validation_error()`,
-  `error_response()`, `not_found_error()`; `Context.case_context`. Registered in `register_tools(mcp)`.
-- **MCP instructions:** `main.py` `MCP_INSTRUCTIONS` (~26–69, tools overview ~30–41) — hand-maintained.
+  `error_response()`, `not_found_error()`. Registered in `register_tools(mcp)`.
+- **MCP instructions:** `main.py` `MCP_INSTRUCTIONS` (~26–69) — hand-maintained.
 
 ### Frontend facts
 - **Case detail:** `frontend/src/pages/cases/detail.tsx` renders `<CaseNotesPanel/>` and
-  `<CaseActivityFeed caseId={...}/>` in a right column (~315). Mount the new Work Log card here.
-- **Feed pattern:** `frontend/src/pages/cases/components/case-activity-feed.tsx` (TanStack Query + card).
+  `<CaseActivityFeed caseId={...}/>` in a right column (~315). Mount the Work Log card here.
+- **Feed pattern:** `frontend/src/pages/cases/components/case-activity-feed.tsx`.
 - **Contact dialog:** `frontend/src/components/common/contact-detail-dialog.tsx` — add an
-  "Interactions" section alongside contact-info / SMS / roles.
+  "Interactions" section.
 - **Service pattern:** `frontend/src/services/cases.ts` (`apiFetch` from `@/lib/api`).
-  **Types:** `frontend/src/types/case.ts`. **Datetime helpers:** `frontend/src/lib/datetime.ts`
-  (`formatDateHeader`, `getDateKey`).
+  **Types:** `frontend/src/types/case.ts`. **Datetime:** `frontend/src/lib/datetime.ts`.
+- **Polling/SSE on the frontend:** there is an existing pattern for reacting to
+  `ai_analyzing`-style async work (intakes) — reuse it (poll the status, or subscribe to
+  the SSE stream) for the "working on it" → "ready" transition.
 - **Conventions:** `@/` imports; `kebab-case.tsx`; **square corners** (no `rounded-*`);
   semantic color tokens; **Hugeicons** (not Lucide); TanStack Query; React Hook Form + Zod;
   shadcn via `npx shadcn@latest add` (check APIs with the shadcn MCP + Context7).
-- **Locate at implementation time:** the **router** (React Router v7 — likely
-  `frontend/src/App.tsx` or a router file) for the `/log` route, and the **app header/sidebar**
-  (`frontend/src/components/layout/`) for the global "Log my day" button.
+- **Locate at impl time:** the **router** (React Router v7 — likely `frontend/src/App.tsx`)
+  for `/log`, and the **app header/sidebar** (`frontend/src/components/layout/`) for the
+  global "Log my day" button.
 
 ---
 
 ## 5. Data Model
 
-Three new tables + two reference columns. Prefer: edit `models.py`, then
+Three new tables. Prefer: edit `models.py`, then
 `alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
 
-### `voice_logs` — one row per session/brain-dump
+### `voice_logs` — one row per logging session
 | column | type | notes |
 |---|---|---|
 | `id` | Integer PK | |
 | `transcript` | Text, nullable | the raw free-text (may be empty if the day was all surfaced items) |
 | `log_date` | Date, not null | the date the work happened (defaults today, editable) |
-| `status` | String(20), not null, default `'draft'` | `'draft'` \| `'confirmed'` |
+| `status` | String(20), not null, default `'processing'` | `'processing'` → `'ready'` → `'confirmed'`; `'failed'` on error |
+| `error` | Text, nullable | failure detail when `status='failed'` |
 | `created_by` | Integer FK→`users.id` SET NULL, nullable | who logged it |
 | `created_at` | DateTime(tz=True), default CURRENT_TIMESTAMP | |
 | `confirmed_at` | DateTime(tz=True), nullable | set when confirmed |
@@ -185,14 +210,15 @@ Three new tables + two reference columns. Prefer: edit `models.py`, then
 | `voice_log_id` | Integer FK→`voice_logs.id` CASCADE, not null | |
 | `case_id` | Integer FK→`cases.id` SET NULL, **nullable** | NULL = unmatched |
 | `minutes` | Integer, not null | AI estimate, user-adjustable |
-| `description` | Text, not null | concise summary |
+| `description` | Text, not null | concise summary (the AI's merged/smashed text) |
 | `raw_reference` | Text, nullable | original phrase / case_guess (preserved, esp. unmatched) |
 | `activity_date` | Date, not null | denormalized from `log_date` for per-case/day queries |
-| `source_type` | String(20), nullable | `'manual'` \| `'event'` \| `'task'` \| `'comment'` |
-| `source_id` | Integer, nullable | id of the linked event/task/case_comment (NULL for manual) |
 | `created_at` | DateTime(tz=True), default CURRENT_TIMESTAMP | |
 
-Indexes: `case_id`, `voice_log_id`, `activity_date`, `(source_type, source_id)`.
+> **No `source_type`/`source_id`.** Surfaced items are merged into the description by the
+> AI; we don't keep references back to the source rows.
+
+Indexes: `case_id`, `voice_log_id`, `activity_date`.
 
 ### `worklog_entry_people` — junction (entry ↔ persons, many-to-many)
 | column | type | notes |
@@ -205,54 +231,70 @@ Index: `person_id`.
 **SQLAlchemy notes:** follow `models.py` conventions — `Mapped`/`mapped_column`,
 `DateTime(timezone=True)` (UTC), `server_default=text("CURRENT_TIMESTAMP")`, explicit
 `ForeignKeyConstraint`+`Index` in `__table_args__`, `relationship(..., passive_deletes=True)`.
-Add a `worklog_entries` relationship to `Case`. Use `func.now()` / `datetime.now(timezone.utc)`.
+Add a `Case.worklog_entries` relationship. Use `func.now()` / `datetime.now(timezone.utc)`.
 
 ---
 
 ## 6. Backend Implementation
 
 ### 6.1 `models.py`
-Add `VoiceLog`, `WorklogEntry`, `WorklogEntryPerson` (§5) + a `Case.worklog_entries` relationship.
+Add `VoiceLog`, `WorklogEntry`, `WorklogEntryPerson` (§5) + `Case.worklog_entries`.
 
 ### 6.2 Migration
 `alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
 
-### 6.3 `db/worklog.py` (mirror `db/notes.py`)
+### 6.3 `db/worklog.py` (mirror `db/notes.py`; status helpers mirror `db/intakes.py`)
 ```python
 def get_worklog_candidates(log_date, user_id) -> dict
-# Returns {"events":[...], "tasks":[...], "comments":[...]} for log_date,
-# scoped to the user's cases (case.attorney_ids/paralegal_ids contains user_id; fall back to all).
-# Each candidate: {source_type, source_id, case_id, case_name, short_name, description,
-#                  anchored_minutes|None, when}. anchored_minutes derived from event time/end_date.
-# events: db.events filtered date==log_date. tasks: completion_date==log_date (and/or
-# updated_at::date==log_date with status terminal). comments: user-authored (NON-is_system)
-# case_comments created on log_date — each is a candidate work item (refine filter per §4).
+# {"events":[...], "tasks":[...], "comments":[...]} for log_date, scoped to the user's cases
+# (case.attorney_ids/paralegal_ids contains user_id; fall back to all). Each candidate:
+# {source_type, source_id, case_id, case_name, short_name, description, anchored_minutes|None, when}.
+# (source_type/source_id are used ONLY to fetch context in Phase 2 — they are NOT stored on entries.)
+# events: date==log_date. tasks: completion_date==log_date (and/or updated_at::date==log_date,
+# terminal status). comments: user-authored NON-is_system case_comments created on log_date.
 
-def create_worklog_draft(transcript, log_date, created_by, entries) -> dict
-# Creates VoiceLog(status='draft') + WorklogEntry rows + people junction, ONE transaction.
-# entries: [{case_id|None, minutes, description, raw_reference, source_type, source_id, person_ids}]
+def create_processing_log(transcript, log_date, created_by) -> int
+# Insert a voice_log with status='processing'; return its id (route returns immediately).
 
-def get_worklog_draft(voice_log_id) -> dict | None        # for deferred confirmation
-def list_worklog_drafts(user_id) -> list                  # "needs review"
-def confirm_worklog(voice_log_id, entries) -> dict        # apply edits, status='confirmed', confirmed_at=now
-def get_worklog_by_case(case_id) -> dict                  # confirmed only; entries + total minutes, grouped by date
-def get_worklog_by_person(person_id) -> dict              # confirmed only; entries + case info
-def update_worklog_entry(entry_id, **fields) -> dict|None # post-hoc edit (optional)
-def delete_worklog_entry(entry_id) -> bool                # optional
-def delete_worklog_draft(voice_log_id) -> bool            # discard an abandoned draft
+def set_worklog_status(voice_log_id, status, error=None) -> None     # mirror set_ai_analyzing
+def save_consolidated_entries(voice_log_id, entries) -> dict          # mirror save_ai_analysis:
+# delete any existing entries for this log, insert the new entries + people junction,
+# set status='ready'. entries: [{case_id|None, minutes, description, raw_reference, person_ids}]
+
+def get_worklog(voice_log_id) -> dict | None      # voice_log + entries (for polling + review)
+def list_pending_worklogs(user_id) -> list        # status in ('processing','ready') — "needs review"
+def confirm_worklog(voice_log_id, transcript, log_date, entries) -> dict
+# Apply the user's edits, set status='confirmed', confirmed_at=now.
+def get_worklog_by_case(case_id) -> dict          # CONFIRMED only; entries + total, grouped by date
+def get_worklog_by_person(person_id) -> dict      # CONFIRMED only; entries + case info
+def delete_worklog(voice_log_id) -> bool          # discard
+def update_worklog_entry(entry_id, **fields) -> dict|None   # post-hoc edit (optional)
+def delete_worklog_entry(entry_id) -> bool                  # optional
 ```
-`get_worklog_by_case`/`by_person` must filter to `voice_logs.status == 'confirmed'`.
-Eager-load people + case names (`selectinload`/joins) to avoid N+1. Export in `db/__init__.py`.
+`get_worklog_by_case`/`by_person` must filter `voice_logs.status == 'confirmed'`. Eager-load
+people + case names to avoid N+1. Export all in `db/__init__.py`.
 
-### 6.4 `services/worklog_consolidator.py` (near-twin of `services/case_extractor.py`)
-Inputs: `transcript`, `log_date`, the **selected surfaced items** (resolved to their
-descriptions/anchored durations), and **candidate cases/contacts** (id + name; lean;
-prompt-cache if large). Single forced tool `submit_worklog`:
-
+### 6.4 `services/worklog_consolidator.py` (LLM = `case_extractor`; async = `intake_ai`)
+**`run_worklog_consolidation(voice_log_id, transcript, log_date, selections, user_id)`** — the
+background-thread entry point (mirrors `services/intake_ai.py:run_background_analysis`):
+```python
+def run_worklog_consolidation(voice_log_id, transcript, log_date, selections, user_id):
+    try:
+        # 1. Resolve `selections` (list of {source_type, source_id}) to their text/case/duration
+        #    via db.get_worklog_candidates or targeted lookups.
+        # 2. Gather candidate cases + contacts (id+name) for matching (prompt-cache if large).
+        # 3. Call Claude (forced submit_worklog tool) -> entries.
+        # 4. db.save_consolidated_entries(voice_log_id, entries)  # sets status='ready'
+        # 5. broadcast({"entity":"worklog","action":"ready","id":voice_log_id, ...})
+    except Exception as e:
+        db.set_worklog_status(voice_log_id, "failed", error=str(e))
+        # broadcast failure too
+```
+Forced tool (no source fields — merge, don't link):
 ```python
 SUBMIT_WORKLOG_TOOL = {
   "name": "submit_worklog",
-  "description": "Submit the consolidated work-log entries.",
+  "description": "Submit the consolidated work-log entries for the day.",
   "input_schema": {"type":"object","properties":{"entries":{"type":"array","items":{
     "type":"object","properties":{
       "description":{"type":"string"},
@@ -260,50 +302,46 @@ SUBMIT_WORKLOG_TOOL = {
       "case_id":{"type":["integer","null"]},
       "case_guess":{"type":"string","description":"How the user referred to the case (for unmatched display)."},
       "person_ids":{"type":"array","items":{"type":"integer"}},
-      "source_type":{"type":"string","enum":["manual","event","task","comment"]},
-      "source_id":{"type":["integer","null"]},
       "raw_reference":{"type":"string"}
-    },"required":["description","minutes","source_type","raw_reference"]}}},
+    },"required":["description","minutes","raw_reference"]}}},
     "required":["entries"]}
 }
 ```
 `tool_choice={"type":"tool","name":"submit_worklog"}`; read `block.input["entries"]`;
 `record_usage_from_message(source="worklog_consolidator", request_type="consolidate", ...)`.
-**Does not persist** — returns entries to the route.
 
-**System prompt** must encode the philosophy, the surfaced-item handling, the two-pass
-logic, AI task-duration estimation, and the day budget:
+**System prompt** (philosophy + merge + two-pass + AI task estimation + day budget):
 ```
 You convert a lawyer's day into discrete work-log entries.
 
 INPUTS:
 - Selected items already on record (events, completed tasks, case comments), each with a
-  case, a description, and sometimes an anchored duration. A comment represents work that
-  took time (a call, a review, a follow-up) — treat it as a real activity.
+  case, a description, and sometimes an anchored duration. MERGE these in as activities —
+  smash each item's context into the unified entry format. A comment represents work that
+  took time (a call, a review, a follow-up).
 - A free-text memo of everything else.
 - Candidate cases and contacts to match against.
 
-STEP 1 — SPLIT the memo into separate activities (one activity = one case). Merge each
-selected item in as its own activity, carrying its source_type/source_id and case.
+STEP 1 — SPLIT & MERGE: Break the memo into separate activities (one activity = one case),
+and fold each selected item in as its own activity. Combine details where they describe the
+same piece of work.
 
 STEP 2 — ESTIMATE DURATIONS:
 - Events with a real start/end time keep that length (anchored).
 - A comment/call with no stated length ≈ 30 min (longer if the text implies more).
-- TASKS: estimate from the task description and typical legal effort (a quick filing vs.
-  drafting a brief). Use judgment; do NOT use one rigid number.
+- TASKS: estimate from the description and typical legal effort (quick filing vs. drafting a
+  brief). Use judgment; do NOT use one rigid number.
 - Free-text work: estimate from cues ("spent the morning" = a substantial block).
 
 STEP 3 — FIT THE DAY: The total across ALL entries must read like a realistic working day,
 roughly 5–7 hours, and MUST NOT exceed 7 hours (420 minutes). Anchored items keep their
-lengths; flexible work (tasks, "the morning") absorbs the remainder and is scaled to fit.
-If anchored items alone exceed 7h, keep them accurate and let the total exceed — the user
-will adjust. Never pad with invented activities; only distribute time across what's given.
+lengths; flexible work absorbs the remainder and is scaled to fit. If anchored items alone
+exceed 7h, keep them accurate and let the total exceed — the user will adjust. Never pad with
+invented activities; only distribute time across what's given.
 
-STEP 4 — MATCH each activity to a case (fuzzy by name) and to people from the candidate
-lists. If no confident case match: case_id=null, put the user's phrasing in case_guess.
-Set source_type='manual', source_id=null for free-text-only entries. ALWAYS fill raw_reference.
-
-Use the submit_worklog tool; entries in chronological order.
+STEP 4 — MATCH each activity to a case (fuzzy by name) and to people from the candidate lists.
+No confident case match -> case_id=null, put the user's phrasing in case_guess. ALWAYS fill
+raw_reference. Use the submit_worklog tool; entries in chronological order.
 ```
 
 ### 6.5 `schemas/inputs.py` / `schemas/outputs.py`
@@ -323,47 +361,43 @@ class WorklogEntryInput(BaseModel):
     minutes: int
     description: str
     raw_reference: Optional[str] = None
-    source_type: Optional[str] = "manual"
-    source_id: Optional[int] = None
     person_ids: list[int] = []
 
-class ConfirmWorklogInput(BaseModel):           # used by confirm + "save draft"
-    voice_log_id: Optional[int] = None
+class ConfirmWorklogInput(BaseModel):
     transcript: str = ""
     log_date: Optional[str] = None
     entries: list[WorklogEntryInput]
 ```
 **Outputs:** `WorklogCandidateOut`, `WorklogEntryOut` (id, case_id, case_name, short_name,
-minutes, description, raw_reference, activity_date, source_type, source_id, created_at,
-`people: list[{id,name}]`), `ParsedWorklogEntryOut` (adds `case_guess`),
-`WorklogDraftOut` (voice_log + entries). `from_attributes=True`; no `__all__` needed.
+minutes, description, raw_reference, activity_date, created_at, `people: list[{id,name}]`,
+plus `case_guess` for the review step), `WorklogOut` (voice_log fields incl. `status`/`error`
++ `entries`). `from_attributes=True`; no `__all__` needed.
 
-### 6.6 `routes/worklog.py` → `register_worklog_routes(mcp)` (mirror `routes/notes.py`)
+### 6.6 `routes/worklog.py` → `register_worklog_routes(mcp)` (mirror `routes/notes.py` + `routes/intakes.py`)
 All `auth.require_auth`; DB via `asyncio.to_thread`; `created_by` from `auth.get_current_user`.
 
 | Method | Path | Phase | Purpose |
 |---|---|---|---|
-| GET | `/api/v1/worklog/candidates?date=YYYY-MM-DD` | 1 | Surfaced items for the date (events/tasks/comments), scoped to the user. |
-| POST | `/api/v1/worklog/consolidate` | 2 | Body `ConsolidateWorklogInput`. Resolves selections, runs the consolidator, **saves a draft**, returns `WorklogDraftOut`. |
-| GET | `/api/v1/worklog/drafts` | 3 | List pending drafts ("needs review"). |
-| GET | `/api/v1/worklog/{voice_log_id}` | 3 | Fetch one draft for deferred confirmation. |
-| POST | `/api/v1/worklog/{voice_log_id}/confirm` | 3 | Body `ConfirmWorklogInput`. Apply edits, set `confirmed`. |
-| DELETE | `/api/v1/worklog/{voice_log_id}` | 3 | Discard an abandoned draft. |
-| GET | `/api/v1/worklog/by-case/{case_id}` | view | Confirmed entries + total for a case. |
+| GET | `/api/v1/worklog/candidates?date=YYYY-MM-DD` | 1 | Surfaced items (events/tasks/comments), scoped to the user. |
+| POST | `/api/v1/worklog/consolidate` | 2 | Body `ConsolidateWorklogInput`. **`db.create_processing_log(...)` → spawn `threading.Thread(target=run_worklog_consolidation, args=(id, transcript, log_date, selections, user_id), daemon=True).start()` → return `{voice_log_id, status:"processing"}` immediately.** |
+| GET | `/api/v1/worklog/{voice_log_id}` | 2/3 | Poll status + fetch entries (for "working on it" → review). |
+| GET | `/api/v1/worklog/pending` | 3 | Logs in `processing`/`ready` — the "needs review" list. |
+| POST | `/api/v1/worklog/{voice_log_id}/confirm` | 3 | Body `ConfirmWorklogInput`. Apply edits → `confirmed`. |
+| DELETE | `/api/v1/worklog/{voice_log_id}` | 3 | Discard. |
+| GET | `/api/v1/worklog/by-case/{case_id}` | view | Confirmed entries + total. |
 | GET | `/api/v1/worklog/by-person/{person_id}` | view | Confirmed entries for a contact. |
 | PATCH/DELETE | `/api/v1/worklog/entries/{entry_id}` | view | Post-hoc edit/delete (optional v1.1). |
 
-Register in `routes/__init__.py` **before** the static block; add to `__all__`.
+Register in `routes/__init__.py` **before** the static block; add to `__all__`. Optionally
+`broadcast(...)` on status changes for live UI (mirror intakes).
 
 ### 6.7 MCP tool (secondary — include if time allows)
-Add `log_work` to `tools.py`: accept already-structured entries (Claude resolves
-cases/people via the existing `search` tool, like `import_case` does) → `db.create_worklog_draft`
-(or directly confirmed). Add `LogWorkInput` to `schemas/inputs.py`. **Document it in
-`MCP_INSTRUCTIONS`** (hand-maintained).
+`log_work` in `tools.py`: accept already-structured entries (Claude resolves cases/people
+via the existing `search` tool) → save directly as a `confirmed` log. Add `LogWorkInput` to
+`schemas/inputs.py`; **document in `MCP_INSTRUCTIONS`**.
 
 ### 6.8 Dockerfile
-**No change needed** — all files land in already-copied dirs (`db/`, `routes/`,
-`services/`, `schemas/`).
+**No change needed** — all files land in already-copied dirs.
 
 ---
 
@@ -372,50 +406,47 @@ cases/people via the existing `search` tool, like `import_case` does) → `db.cr
 Order: **types → service → components → page → wire-in.**
 
 ### 7.1 Types — `frontend/src/types/worklog.ts`
-`WorklogCandidate` (source_type, source_id, case_id, case_name, description,
-anchored_minutes, when), `WorklogEntry`, `ParsedWorklogEntry` (+ case_guess),
-`WorklogDraft` (voice_log fields + entries[]).
+`WorklogCandidate`, `WorklogEntry` (+ `case_guess`), `Worklog` (voice_log fields incl.
+`status`/`error` + `entries[]`).
 
 ### 7.2 Service — `frontend/src/services/worklog.ts` (mirror `services/cases.ts`)
-`getWorklogCandidates(date)`, `consolidateWorklog(payload)`, `listWorklogDrafts()`,
-`getWorklogDraft(id)`, `confirmWorklog(id, payload)`, `discardWorklogDraft(id)`,
-`getWorklogByCase(caseId)`, `getWorklogByPerson(personId)`.
+`getWorklogCandidates(date)`, `consolidateWorklog(payload)` (returns `{voice_log_id, status}`),
+`getWorklog(id)` (poll), `listPendingWorklogs()`, `confirmWorklog(id, payload)`,
+`discardWorklog(id)`, `getWorklogByCase(caseId)`, `getWorklogByPerson(personId)`.
 
 ### 7.3 Page — `frontend/src/pages/worklog/index.tsx` (+ `components/`)
-Three-phase stepper:
+Stepper:
 1. **Input** (`worklog-input.tsx`): date picker (defaults today) → `getWorklogCandidates`
-   → render grouped multi-select (Events / Completed Tasks / Comments), each row showing
-   case + description + suggested time, checkbox to include. Plus a `<Textarea>` for
-   free-form. "Consolidate" button.
-2. **Consolidate:** `useMutation(consolidateWorklog)` with selections + transcript →
-   returns a draft → advance to review. Loading state.
-3. **Confirm** (`worklog-review.tsx`): editable list — description, `minutes` input (or
-   quick chips), searchable **case combobox** (warning chip when `case_id` null, shows
-   `case_guess`), **people multi-select**. **Running day total** at top with a subtle
-   over-7h warning. Buttons: **Confirm** (`confirmWorklog`) and **Save for later** (keeps
-   it a draft). Don't gate saving on required fields.
+   → grouped multi-select (Events / Completed Tasks / Comments), each row showing case +
+   description + suggested time + checkbox. Plus a `<Textarea>` for free-form. "Consolidate".
+2. **Processing** (async): on `consolidateWorklog`, get back `{voice_log_id, status:'processing'}`.
+   Show a "working on it — you can come back later" state and **poll `getWorklog(id)`** (or
+   subscribe to SSE) until `status==='ready'` (or `'failed'`). The user may leave the page;
+   the log stays in the **pending** list.
+3. **Confirm** (`worklog-review.tsx`): once `ready`, editable list — description, `minutes`
+   input (or quick chips), searchable **case combobox** (warning chip + `case_guess` when
+   null), **people multi-select**, **running day total** with an over-7h warning. **Confirm**
+   (`confirmWorklog`) or leave it pending. Don't gate saving on required fields.
 
-Also surface a **"Drafts to review"** entry (badge/list via `listWorklogDrafts`) so a
-deferred draft can be reopened into the review step.
+Also surface a **"To review"** entry (badge/list via `listPendingWorklogs`) so a processing
+or ready log can be reopened — supporting "come back later."
 
-shadcn: `Command`/Combobox, `Checkbox`, `Input`, `Badge`, `Textarea`, `Button`, `Tabs` or a
-stepper. **Square corners, Hugeicons, semantic tokens, `@/` imports.** Verify component
-APIs via the shadcn MCP.
+shadcn: `Command`/Combobox, `Checkbox`, `Input`, `Badge`, `Textarea`, `Button`, stepper/`Tabs`.
+**Square corners, Hugeicons, semantic tokens, `@/` imports.** Verify APIs via the shadcn MCP.
 
 ### 7.4 Case detail card — `frontend/src/pages/cases/components/case-work-log.tsx`
 `useQuery(["worklog-by-case", caseId], () => getWorklogByCase(caseId))`; group by
-`activity_date` (use `lib/datetime.ts`); show description, minutes, people chips,
-source-type icon, and a **case time total** in the header. Mount in `detail.tsx` near
-`<CaseActivityFeed/>`. Recommend **always-on** (not `feature_toggles`-gated).
+`activity_date` (`lib/datetime.ts`); show description, minutes, people chips, and a **case
+time total**. Mount in `detail.tsx` near `<CaseActivityFeed/>`. **Always-on** (not toggle-gated).
 
 ### 7.5 Contact "Interactions" section — in `contact-detail-dialog.tsx`
 `useQuery(["worklog-by-person", personId], ...)`; list activities naming this person, by
 date, each linking to its case. Place near the SMS / roles sections.
 
 ### 7.6 Wire-in (locate first)
-- **Router:** add `/log` → `pages/worklog/index.tsx` (React Router v7 route table).
-- **Header/nav:** global "Log my day" button (Hugeicons mic/pencil) in
-  `components/layout/` → navigates to `/log`. Consider a small badge when drafts await review.
+- **Router:** add `/log` → `pages/worklog/index.tsx`.
+- **Header/nav:** global "Log my day" button (Hugeicons mic/pencil) in `components/layout/`;
+  consider a badge when items await review (`listPendingWorklogs`).
 
 ---
 
@@ -424,14 +455,15 @@ date, each linking to its case. Place near the SMS / roles sections.
 1. `models.py` (+ `Case` relationship).
 2. `alembic revision --autogenerate -m "add worklog tables"` → review → `alembic upgrade head`.
 3. `schemas/inputs.py` + `schemas/outputs.py`.
-4. `db/worklog.py` → candidates, draft create, confirm, by-case/person; export in `db/__init__.py`.
-5. `services/worklog_consolidator.py`.
-6. `routes/worklog.py` → register in `routes/__init__.py` (before static).
+4. `db/worklog.py` → candidates, `create_processing_log`, `set_worklog_status`,
+   `save_consolidated_entries`, `confirm_worklog`, by-case/person; export in `db/__init__.py`.
+5. `services/worklog_consolidator.py` → `run_worklog_consolidation` (background) + the LLM call.
+6. `routes/worklog.py` → consolidate spawns the thread + returns immediately; register before static.
 7. (Optional) `tools.py` `log_work` + `MCP_INSTRUCTIONS`.
-8. Restart with `/dev`; smoke-test with `curl`: candidates → consolidate (draft) → confirm
-   → by-case → by-person; verify drafts list + deferred confirm.
-9. Frontend: types → service → input + review components → page (stepper + drafts) → case
-   card → contact section → router + header.
+8. Restart with `/dev`; smoke-test with `curl`: candidates → consolidate (returns processing)
+   → poll `GET /worklog/{id}` until `ready` → confirm → by-case/person; check the pending list.
+9. Frontend: types → service → input + processing + review components → page → case card →
+   contact section → router + header.
 10. `cd frontend && npm run type-check && npm run build`; visual pass via `/dev`.
 
 ---
@@ -440,50 +472,54 @@ date, each linking to its case. Place near the SMS / roles sections.
 
 **Backend**
 - [ ] `alembic upgrade head` clean; `alembic check` in sync.
-- [ ] `GET /worklog/candidates?date=…` returns the right events/tasks/comments for the date
-      (non-`is_system` comments only), scoped to the user, with anchored durations on timed events.
-- [ ] `POST /worklog/consolidate` saves a **draft** and returns entries; total is ~5–7h and
-      **never > 7h** (unless anchored items alone exceed it); tasks get sensible AI estimates;
-      surfaced items carry `source_type`/`source_id`; unmatched case → `case_id null` + `case_guess`.
-- [ ] Drafts list + `GET /worklog/{id}` support **deferred** confirmation.
-- [ ] `POST /worklog/{id}/confirm` flips status to `confirmed`, applies edits.
-- [ ] `by-case` / `by-person` return **confirmed-only** data with correct totals.
+- [ ] `GET /worklog/candidates?date=…` returns the right events/tasks/comments (non-`is_system`
+      comments only), scoped to the user, with anchored durations on timed events.
+- [ ] `POST /worklog/consolidate` **returns immediately** with `status:'processing'`; the
+      background thread populates entries and flips to `ready`; errors flip to `failed` with
+      an `error` message (and never leave the flag stuck except on hard restart).
+- [ ] Consolidated total is ~5–7h and **never > 7h** (unless anchored items alone exceed it);
+      tasks get sensible AI estimates; surfaced items are merged into descriptions; unmatched
+      case → `case_id null` + `case_guess`.
+- [ ] `GET /worklog/{id}` supports polling; `GET /worklog/pending` lists processing+ready.
+- [ ] `POST /worklog/{id}/confirm` flips to `confirmed`, applies edits.
+- [ ] `by-case`/`by-person` return **confirmed-only** data with correct totals.
 - [ ] Token usage row written (`source='worklog_consolidator'`). Unauthed → 401.
 
 **Frontend**
 - [ ] `npm run type-check` + `npm run build` pass.
 - [ ] Phase 1: candidates render as multi-select + free-text works.
-- [ ] Phase 2 → Phase 3: editable review with running total + over-7h warning.
-- [ ] "Save for later" persists a draft; reopening from the drafts list lands back in review.
+- [ ] Phase 2: shows "working on it," lets the user leave, and the log appears in "To review";
+      the page reacts when it becomes `ready` (poll/SSE).
+- [ ] Phase 3: editable review with running total + over-7h warning; confirm persists.
 - [ ] Case card (grouped by day, total) + contact Interactions section render.
 - [ ] Square corners, Hugeicons, semantic tokens, `@/` imports.
 
 **Behavioral**
-- [ ] Selecting a deposition event + typing "drafted the Reyes brief" yields two entries; the
-      day totals to a believable ≤7h.
+- [ ] Selecting a deposition event + a couple of case comments + typing "drafted the Reyes
+      brief" yields merged entries totaling a believable ≤7h.
 - [ ] No clarifying questions are ever asked; durations are estimated silently.
-- [ ] A selected item already logged once does not re-surface on a later visit.
+- [ ] Firing consolidation and navigating away, then returning later, lands in review.
 
 ---
 
 ## 10. Open Decisions for the Implementer
 
-1. **7-hour rule: hard vs soft.** Plan treats it as a target band (5–7h) with a 7h ceiling
-   the AI won't cross, **except** when anchored events legitimately exceed it (then keep
-   them accurate). The user can always override durations in confirmation. Confirm this is desired.
+1. **7-hour rule: hard vs soft.** Target band (5–7h), 7h ceiling the AI won't cross **except**
+   when anchored events legitimately exceed it. User overrides in confirmation. Confirm desired.
 2. **"Done today" task filter.** `completion_date == log_date` only, or also
-   `updated_at::date == log_date` for partially-done/status-changed tasks? (Plan: both,
-   labeled.)
-3. **Comment candidates.** Surface all user-authored (non-`is_system`) `case_comments` for
-   the date as work candidates (a comment generally reflects time spent). `is_system` audit
-   lines are excluded. Decide whether to also include the polymorphic `comments` table, and
-   whether any further filtering is wanted.
-4. **Active-case scope for matching.** User's cases first (via `attorney_ids`/`paralegal_ids`),
+   `updated_at::date == log_date` for status-changed tasks? (Plan: both, labeled.)
+3. **Comment candidates.** Surface all user-authored (non-`is_system`) `case_comments` for the
+   date. Decide whether to also include the polymorphic `comments` table and any extra filtering.
+4. **Active-case scope for matching.** User's cases first (`attorney_ids`/`paralegal_ids`),
    fall back to all when small. Keep candidate lists lean; prompt-cache if large.
-5. **Draft housekeeping.** Auto-expire/clean abandoned drafts? (Plan: provide a delete; no auto-expiry v1.)
-6. **MCP `log_work` tool** — ship in v1 or defer.
-7. **`minutes` display** — store integer minutes; render "1h 30m" via a `lib/` formatter.
-8. **Multi-user views** — show all firm entries or filter to current user? (Small firm:
+5. **Re-surfacing.** Without source-linking, the same comment/event can appear as a candidate
+   again if the user re-opens `/log` for the same date. Low-risk (a day is logged once; the
+   user reviews before confirming). Decide whether to bother dedup'ing; v1 can ignore it.
+6. **Stuck `processing` on restart.** In-process thread dies if the server restarts mid-job
+   (same as intakes). Acceptable for v1; consider a "re-run" affordance on a stale log.
+7. **MCP `log_work` tool** — ship in v1 or defer.
+8. **`minutes` display** — store integer minutes; render "1h 30m" via a `lib/` formatter.
+9. **Multi-user views** — show all firm entries or filter to current user? (Small firm:
    default to all, label with initials.)
 
 ---
@@ -494,7 +530,8 @@ date, each linking to its case. Place near the SMS / roles sections.
   `datetime.now(timezone.utc)`; never bare `datetime.now()`.
 - **Route order:** new routes before `register_static_routes` (SPA catch-all is last).
 - **`MCP_INSTRUCTIONS`** is hand-maintained — update if you add the MCP tool.
-- **`-w 1`** stays (no shared in-memory state added here).
+- **`-w 1`** stays. The async consolidation uses an **in-process daemon thread** (like
+  intakes) — no extra workers, no external queue.
 - **Square corners**, **Hugeicons** (not Lucide), **`@/` imports**, **kebab-case files**,
   semantic color tokens. Use the **shadcn MCP** + **Context7** before writing UI.
 - Never push to `main`; stay on `claude/voice-log-case-contact-Qgp6Y`.


### PR DESCRIPTION
## What this is

A **planning document only** — `docs/plans/worklog-feature-plan.md`. No application code
is changed (1 file, +537 lines). The doc is a self-contained, execution-ready spec for a
local Claude session (with DB + deps + dev servers) to implement the feature.

## The feature

Record a short stream-of-consciousness memo once or twice a day; the system turns it into
discrete, time-estimated **work-log entries** linked to cases (and people), so the user can
see everything they did on a case (by day, with a rough time total) and every interaction
with a contact.

## Design we landed on

- **Three-phase flow:**
  1. **Input** — multi-select things already on record for the date (events, completed/updated
     tasks, case comments) + a free-text box for everything else.
  2. **Consolidation (async)** — an in-process background thread (mirroring the existing
     intake AI pattern) splits/merges the inputs, estimates durations (incl. AI-estimated task
     time), fits a realistic **5–7h day capped at ~7h**, and matches cases/people. Created as
     `processing`, returns immediately, flips to `ready`; the user can walk away and review later.
  3. **Confirmation** — a one-glance editable review; confirm now or later. Only `confirmed`
     entries count toward totals.
- **Merge, don't link** — surfaced items are merged into the entry text by the AI; no
  source-row back-references (deliberate simplification).
- **Data model** — `voice_logs` (status: processing → ready → confirmed), `worklog_entries`
  (one case each, own `minutes`), `worklog_entry_people` (many-to-many).
- **Not a time tracker** — broad strokes, no nitpicky questions, durations estimated silently.

## Notes

- The plan embeds verified codebase facts: the current Alembic head, the `activity`
  naming collision to avoid, the async AI pattern to mirror (`services/intake_ai.py` +
  `threading.Thread`), and the exact files/patterns for each layer.
- Includes a build sequence, verification checklist, open decisions, and CLAUDE.md guardrails.

https://claude.ai/code/session_01BDAA2MM4o5YNfQizYetcvy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDAA2MM4o5YNfQizYetcvy)_