### PR TITLE
Per-case document tracking (with quick-status chips + N/A bucket)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["dev-node20.sh"],
+      "cwd": "frontend",
+      "port": 5173
+    }
+  ]
+}

--- a/alembic/versions/f7a1c9e4d2b8_add_case_checklist_items_table.py
+++ b/alembic/versions/f7a1c9e4d2b8_add_case_checklist_items_table.py
@@ -1,0 +1,48 @@
+"""add case_checklist_items table
+
+Revision ID: f7a1c9e4d2b8
+Revises: 119108f0b1bc
+Create Date: 2026-06-04 17:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f7a1c9e4d2b8'
+down_revision: Union[str, Sequence[str], None] = '119108f0b1bc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'case_checklist_items',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('case_id', sa.Integer(), nullable=False),
+        sa.Column('item_key', sa.String(length=60), nullable=False),
+        sa.Column('label', sa.String(length=120), nullable=True),
+        sa.Column('status', sa.String(length=20),
+                  server_default=sa.text("'needed'::character varying"), nullable=False),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('sort_order', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                  server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True),
+                  server_default=sa.text('CURRENT_TIMESTAMP'), nullable=True),
+        sa.ForeignKeyConstraint(['case_id'], ['cases.id'],
+                                name='case_checklist_items_case_id_fkey', ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id', name='case_checklist_items_pkey'),
+        sa.UniqueConstraint('case_id', 'item_key', name='uq_case_checklist_items_case_key'),
+    )
+    op.create_index('idx_case_checklist_items_case_id', 'case_checklist_items', ['case_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_case_checklist_items_case_id', table_name='case_checklist_items')
+    op.drop_table('case_checklist_items')

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -383,6 +383,16 @@ from .comments import (
     get_unread_counts as get_comment_unread_counts,
 )
 
+# Document tracking checklist
+from .checklist import (
+    get_checklist,
+    set_checklist_item,
+    add_custom_item as add_checklist_custom_item,
+    delete_checklist_item,
+    get_item_comments as get_checklist_item_comments,
+    add_item_comment as add_checklist_item_comment,
+)
+
 # Trial calendar
 from .trial_calendar import (
     get_trial_calendar,
@@ -604,6 +614,13 @@ __all__ = [
     "mark_intake_read",
     "get_unread_counts",
     "get_recent_activity",
+    # Document tracking checklist
+    "get_checklist",
+    "set_checklist_item",
+    "add_checklist_custom_item",
+    "delete_checklist_item",
+    "get_checklist_item_comments",
+    "add_checklist_item_comment",
     # SMS
     "list_sms_conversations",
     "get_sms_conversation",

--- a/db/checklist.py
+++ b/db/checklist.py
@@ -1,0 +1,321 @@
+"""
+Per-case document tracking — the "Document Tracking" card.
+
+A fixed catalog of intake documents/authorizations (defined here in code) is
+overlaid with sparse per-case rows. A row in `case_checklist_items` is created
+lazily, only when an item is actually acted on (status moved off the default,
+notes added, a comment posted, or a custom item added). Untouched catalog items
+are *virtual* — they have no row and report the default "needed" status. This
+keeps the `documents` feature toggle freely reversible (a freshly-enabled case
+has zero rows) and lets the catalog evolve without backfilling existing cases.
+
+The per-item activity log reuses the polymorphic `comments` table via
+db/comments.py with entity_type="checklist_item".
+"""
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select, func, delete
+
+from .session import SessionLocal
+from . import comments as comments_db
+from models import CaseChecklistItem, Comment
+
+# Entity type used in the polymorphic comments table for item activity logs.
+CHECKLIST_ENTITY = "checklist_item"
+
+# Valid statuses (default first). Kept here rather than in schemas/common.py
+# because this is web-UI-only and not surfaced as an MCP enum.
+STATUSES = ("needed", "in_progress", "partial", "complete", "na")
+DEFAULT_STATUS = "needed"
+
+_STATUS_LABELS = {
+    "needed": "To do",
+    "in_progress": "In progress",
+    "partial": "Partial",
+    "complete": "Complete",
+    "na": "N/A",
+}
+
+# The standard catalog: two groups, each an ordered list of (key, label).
+# Mirrors the firm's paper "Client Information Sheet" document checklists.
+CATALOG: list[dict] = [
+    {
+        "key": "authorizations",
+        "label": "Authorizations",
+        "items": [
+            ("signed_retainer", "Signed Retainer"),
+            ("hipaa_auth", "HIPAA Authorization"),
+            ("autopsy_auth", "Authorization — Release of Autopsy"),
+            ("public_records_auth", "Authorization — Release of Public Records"),
+        ],
+    },
+    {
+        "key": "documents",
+        "label": "Documents",
+        "items": [
+            ("photo_id", "Copy of Photo ID / License"),
+            ("death_certificate", "Death Certificate"),
+            ("funeral_expenses", "Funeral & Burial Expense Docs"),
+            ("medical_records", "Medical Records"),
+            ("family_photos", "Family Photographs"),
+            ("ssn_dob", "SSN & DOB"),
+            ("criminal_defense_contact", "Criminal Case / Defense Attorney Contact"),
+            ("av_recordings", "Video / Audio Recordings"),
+            ("work_history", "Work History / Wage Loss Docs"),
+            ("complaint_claim_form", "Copy of Complaint / Claim Form"),
+            ("police_report", "Police / Incident Report"),
+        ],
+    },
+]
+
+# Flat lookup of catalog key -> default label, and key -> sort position.
+_CATALOG_LABELS: dict[str, str] = {}
+_CATALOG_ORDER: dict[str, int] = {}
+for _gi, _g in enumerate(CATALOG):
+    for _ii, (_k, _label) in enumerate(_g["items"]):
+        _CATALOG_LABELS[_k] = _label
+        _CATALOG_ORDER[_k] = _gi * 100 + _ii
+
+
+def _is_custom(item_key: str) -> bool:
+    return item_key.startswith("custom:")
+
+
+def _item_dict(
+    key: str,
+    label: str,
+    row: Optional[CaseChecklistItem],
+    comment_counts: dict[int, int],
+) -> dict:
+    return {
+        "key": key,
+        "label": row.label if (row and row.label) else label,
+        "status": row.status if row else DEFAULT_STATUS,
+        "notes": row.notes if row else None,
+        "id": row.id if row else None,
+        "comment_count": comment_counts.get(row.id, 0) if row else 0,
+        "custom": _is_custom(key),
+        "updated_at": row.updated_at.isoformat() if (row and row.updated_at) else None,
+    }
+
+
+def _comment_counts(session, row_ids: list[int]) -> dict[int, int]:
+    if not row_ids:
+        return {}
+    rows = session.execute(
+        select(Comment.entity_id, func.count(Comment.id))
+        .where(
+            Comment.entity_type == CHECKLIST_ENTITY,
+            Comment.entity_id.in_(row_ids),
+            Comment.is_system.isnot(True),
+        )
+        .group_by(Comment.entity_id)
+    ).all()
+    return {eid: c for eid, c in rows}
+
+
+def get_checklist(case_id: int) -> dict:
+    """Return the merged checklist: catalog items overlaid with persisted rows.
+
+    Shape: {"groups": [{key, label, items: [item...]}], "custom_items": [...]}
+    """
+    with SessionLocal() as session:
+        rows = session.scalars(
+            select(CaseChecklistItem).where(CaseChecklistItem.case_id == case_id)
+        ).all()
+        by_key = {r.item_key: r for r in rows}
+        counts = _comment_counts(session, [r.id for r in rows])
+
+        groups = []
+        for g in CATALOG:
+            items = []
+            for key, label in g["items"]:
+                items.append(_item_dict(key, label, by_key.get(key), counts))
+            groups.append({"key": g["key"], "label": g["label"], "items": items})
+
+        customs = [r for k, r in by_key.items() if _is_custom(k)]
+        customs.sort(key=lambda r: (r.sort_order or 0, r.id))
+        custom_items = [
+            _item_dict(r.item_key, r.label or "Untitled", r, counts) for r in customs
+        ]
+
+        return {"groups": groups, "custom_items": custom_items}
+
+
+def _row_dict(session, row: CaseChecklistItem) -> dict:
+    label = _CATALOG_LABELS.get(row.item_key, row.label or "Untitled")
+    counts = _comment_counts(session, [row.id])
+    return _item_dict(row.item_key, label, row, counts)
+
+
+def set_checklist_item(
+    case_id: int,
+    item_key: str,
+    *,
+    status: Optional[str] = None,
+    notes: Optional[str] = None,
+    user_id: Optional[int] = None,
+) -> Optional[dict]:
+    """Upsert status/notes for a catalog item.
+
+    Materialization guard: if the item has no row yet and the requested state
+    is still the untouched default (status "needed", empty notes), no row is
+    created — the item stays virtual. Logs a system comment when the status
+    actually changes.
+
+    Returns the item dict, or None if the case/item is unknown.
+    """
+    if item_key not in _CATALOG_LABELS and not _is_custom(item_key):
+        return None
+    if status is not None and status not in STATUSES:
+        return None
+
+    with SessionLocal() as session:
+        row = session.scalar(
+            select(CaseChecklistItem).where(
+                CaseChecklistItem.case_id == case_id,
+                CaseChecklistItem.item_key == item_key,
+            )
+        )
+
+        old_status = row.status if row else DEFAULT_STATUS
+        new_status = status if status is not None else old_status
+        new_notes = notes if notes is not None else (row.notes if row else None)
+        if new_notes == "":
+            new_notes = None
+
+        # Nothing persisted yet and the result is still the pristine default →
+        # don't create a row (keeps the feature toggle reversible).
+        if row is None and new_status == DEFAULT_STATUS and not new_notes:
+            return _item_dict(
+                item_key, _CATALOG_LABELS.get(item_key, "Untitled"), None, {}
+            )
+
+        if row is None:
+            row = CaseChecklistItem(
+                case_id=case_id,
+                item_key=item_key,
+                status=new_status,
+                notes=new_notes,
+                sort_order=_CATALOG_ORDER.get(item_key),
+            )
+            session.add(row)
+        else:
+            row.status = new_status
+            row.notes = new_notes
+            row.updated_at = func.now()
+
+        session.flush()
+        result = _row_dict(session, row)
+
+        if new_status != old_status:
+            comments_db.add_comment(
+                CHECKLIST_ENTITY,
+                row.id,
+                user_id,
+                f"changed status to {_STATUS_LABELS.get(new_status, new_status)}",
+                is_system=True,
+                detail={"from": old_status, "to": new_status},
+            )
+            result["comment_count"] = _comment_counts(session, [row.id]).get(row.id, 0)
+
+        session.commit()
+        return result
+
+
+def add_custom_item(case_id: int, label: str) -> dict:
+    """Create a user-defined ("Other") checklist item. Always materializes."""
+    item_key = f"custom:{uuid.uuid4().hex[:12]}"
+    with SessionLocal() as session:
+        max_order = session.scalar(
+            select(func.max(CaseChecklistItem.sort_order)).where(
+                CaseChecklistItem.case_id == case_id
+            )
+        )
+        row = CaseChecklistItem(
+            case_id=case_id,
+            item_key=item_key,
+            label=label.strip()[:120] or "Untitled",
+            status=DEFAULT_STATUS,
+            sort_order=(max_order or 999) + 1,
+        )
+        session.add(row)
+        session.flush()
+        result = _row_dict(session, row)
+        session.commit()
+        return result
+
+
+def delete_checklist_item(case_id: int, item_key: str) -> bool:
+    """Delete an item's row (and its activity log).
+
+    For a custom item this removes it entirely. For a standard item this resets
+    it back to the virtual default ("needed", no notes).
+    """
+    with SessionLocal() as session:
+        row = session.scalar(
+            select(CaseChecklistItem).where(
+                CaseChecklistItem.case_id == case_id,
+                CaseChecklistItem.item_key == item_key,
+            )
+        )
+        if row is None:
+            return False
+        session.execute(
+            delete(Comment).where(
+                Comment.entity_type == CHECKLIST_ENTITY,
+                Comment.entity_id == row.id,
+            )
+        )
+        session.delete(row)
+        session.commit()
+        return True
+
+
+def _resolve_row_id(case_id: int, item_key: str) -> Optional[int]:
+    with SessionLocal() as session:
+        return session.scalar(
+            select(CaseChecklistItem.id).where(
+                CaseChecklistItem.case_id == case_id,
+                CaseChecklistItem.item_key == item_key,
+            )
+        )
+
+
+def get_item_comments(case_id: int, item_key: str) -> list[dict]:
+    """Activity log for one item. Empty when the item has no row yet."""
+    row_id = _resolve_row_id(case_id, item_key)
+    if row_id is None:
+        return []
+    return comments_db.get_comments(CHECKLIST_ENTITY, row_id)
+
+
+def add_item_comment(
+    case_id: int, item_key: str, user_id: Optional[int], content: str
+) -> Optional[dict]:
+    """Add an activity-log entry, materializing the item row if needed."""
+    if item_key not in _CATALOG_LABELS and not _is_custom(item_key):
+        return None
+
+    with SessionLocal() as session:
+        row = session.scalar(
+            select(CaseChecklistItem).where(
+                CaseChecklistItem.case_id == case_id,
+                CaseChecklistItem.item_key == item_key,
+            )
+        )
+        if row is None:
+            row = CaseChecklistItem(
+                case_id=case_id,
+                item_key=item_key,
+                status=DEFAULT_STATUS,
+                sort_order=_CATALOG_ORDER.get(item_key),
+            )
+            session.add(row)
+            session.flush()
+        row_id = row.id
+        session.commit()
+
+    return comments_db.add_comment(CHECKLIST_ENTITY, row_id, user_id, content)

--- a/db/feature_gates.py
+++ b/db/feature_gates.py
@@ -17,6 +17,7 @@ Feature keys (must match the frontend `CaseFeatureKey` union):
     events      -> Event rows
     financials  -> CaseFinancial + CounselFee rows
     costs       -> Invoice + Lien rows (the entire case-costs page)
+    documents   -> CaseChecklistItem rows (the document-tracking card)
 
 Rows with a NULL case_id (e.g., unassigned tasks) are never filtered out
 because they don't belong to any case.
@@ -27,15 +28,19 @@ from typing import Optional
 from sqlalchemy import func, or_, select as sa_select
 from sqlalchemy.orm import Session
 
-from models import Case, Task, Event, CaseFinancial, Invoice, Lien
+from models import Case, Task, Event, CaseFinancial, Invoice, Lien, CaseChecklistItem
 
 
 FEATURE_TASKS = "tasks"
 FEATURE_EVENTS = "events"
 FEATURE_FINANCIALS = "financials"
 FEATURE_COSTS = "costs"
+FEATURE_DOCUMENTS = "documents"
 
-ALL_FEATURES = (FEATURE_TASKS, FEATURE_EVENTS, FEATURE_FINANCIALS, FEATURE_COSTS)
+ALL_FEATURES = (
+    FEATURE_TASKS, FEATURE_EVENTS, FEATURE_FINANCIALS, FEATURE_COSTS,
+    FEATURE_DOCUMENTS,
+)
 
 
 class FeatureDisabled(Exception):
@@ -46,6 +51,7 @@ class FeatureDisabled(Exception):
         FEATURE_EVENTS: "Events",
         FEATURE_FINANCIALS: "Financials",
         FEATURE_COSTS: "Costs",
+        FEATURE_DOCUMENTS: "Documents",
     }
 
     def __init__(self, case_id: int, feature: str):
@@ -105,6 +111,7 @@ def get_feature_data_counts(session: Session, case_id: int) -> dict[str, int]:
         FEATURE_FINANCIALS: session.scalar(sa_select(func.count(CaseFinancial.id)).where(CaseFinancial.case_id == case_id)) or 0,
         FEATURE_COSTS:      (session.scalar(sa_select(func.count(Invoice.id)).where(Invoice.case_id == case_id)) or 0)
                            + (session.scalar(sa_select(func.count(Lien.id)).where(Lien.case_id == case_id)) or 0),
+        FEATURE_DOCUMENTS:  session.scalar(sa_select(func.count(CaseChecklistItem.id)).where(CaseChecklistItem.case_id == case_id)) or 0,
     }
 
 

--- a/frontend/dev-node20.sh
+++ b/frontend/dev-node20.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Launches the Vite dev server for the Claude "preview" MCP / IDE preview tools.
+#
+# Two reasons this wrapper exists:
+#   1. Node version — the preview tool inherits whatever `node` is first on PATH,
+#      which may be older than Vite requires. We source nvm and `nvm use` so the
+#      version pinned in frontend/.nvmrc (20) is selected automatically.
+#   2. Proxy target — the preview MCP injects PORT=<its managed port> into this
+#      process. vite.config.ts uses PORT for the /api proxy target, so without
+#      pinning it the dev server would proxy /api back to itself → 500s. We pin
+#      PORT to the backend (8000) and keep the dev server on VITE_PORT (5173).
+#
+# Referenced by .claude/launch.json. Override PORT/VITE_PORT via env if needed.
+
+[ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh" && nvm use >/dev/null 2>&1
+
+export PORT="${PORT_BACKEND:-8000}"
+export VITE_PORT="${VITE_PORT:-5173}"
+exec npm run dev

--- a/frontend/src/lib/sse-invalidation-map.ts
+++ b/frontend/src/lib/sse-invalidation-map.ts
@@ -77,6 +77,15 @@ export const INVALIDATION_MAP: Record<
     return keys
   },
 
+  checklist: (event) => {
+    const keys: (string | (string | number)[])[] = []
+    if (event.case_id) {
+      keys.push(["checklist", event.case_id])
+      keys.push(["case", event.case_id])
+    }
+    return keys
+  },
+
   invoice: (event) => {
     const keys: (string | (string | number)[])[] = ["invoices", "invoice-stats"]
     if (event.case_id) keys.push(["case-costs", event.case_id])

--- a/frontend/src/pages/cases/components/case-document-tracker.tsx
+++ b/frontend/src/pages/cases/components/case-document-tracker.tsx
@@ -1,0 +1,522 @@
+import { useMemo, useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Add01Icon,
+  CheckmarkCircle02Icon,
+  Delete01Icon,
+  SentIcon,
+} from "@hugeicons/core-free-icons"
+import {
+  getChecklist,
+  setChecklistItem,
+  addCustomChecklistItem,
+  deleteChecklistItem,
+  getChecklistComments,
+  addChecklistComment,
+} from "@/services/checklist"
+import {
+  CHECKLIST_STATUS_META,
+  CHECKLIST_STATUS_ORDER,
+  type ChecklistItem,
+  type ChecklistStatus,
+} from "@/types/checklist"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardAction,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Skeleton } from "@/components/ui/skeleton"
+import { timeAgo } from "@/lib/datetime"
+import { cn } from "@/lib/utils"
+
+interface CaseDocumentTrackerProps {
+  caseId: number
+}
+
+const STATUS_BADGE: Record<ChecklistStatus, string> = {
+  needed: "bg-muted text-muted-foreground",
+  in_progress: "bg-info text-info-foreground",
+  partial: "bg-warning text-warning-foreground",
+  complete: "bg-success text-success-foreground",
+  na: "bg-muted text-muted-foreground",
+}
+
+export function CaseDocumentTracker({ caseId }: CaseDocumentTrackerProps) {
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+  const [showNa, setShowNa] = useState(false)
+  const [addingCustom, setAddingCustom] = useState(false)
+  const [customLabel, setCustomLabel] = useState("")
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["checklist", caseId],
+    queryFn: () => getChecklist(caseId),
+  })
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["checklist", caseId] })
+    // feature_data_counts on the case drives the section's toggle lock.
+    queryClient.invalidateQueries({ queryKey: ["case", caseId] })
+  }
+
+  const addCustom = useMutation({
+    mutationFn: (label: string) => addCustomChecklistItem(caseId, label),
+    onSuccess: () => {
+      setCustomLabel("")
+      setAddingCustom(false)
+      invalidate()
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const allItems = useMemo(() => {
+    if (!data) return [] as ChecklistItem[]
+    return [...data.groups.flatMap((g) => g.items), ...data.custom_items]
+  }, [data])
+
+  const summary = useMemo(() => {
+    const visible = allItems.filter((i) => i.status !== "na")
+    const complete = visible.filter((i) => i.status === "complete").length
+    const active = visible.filter(
+      (i) => i.status === "in_progress" || i.status === "partial"
+    ).length
+    const todo = visible.filter((i) => i.status === "needed").length
+    return { total: visible.length, complete, active, todo }
+  }, [allItems])
+
+  const naCount = allItems.filter((i) => i.status === "na").length
+
+  return (
+    <Card size="sm">
+      <CardHeader className="border-b bg-muted/40">
+        <CardTitle>Document Tracking</CardTitle>
+        <CardAction>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
+            onClick={() => setAddingCustom((v) => !v)}
+          >
+            <HugeiconsIcon icon={Add01Icon} className="size-3.5" />
+            Item
+          </Button>
+        </CardAction>
+        {summary.total > 0 && (
+          <div className="col-span-full mt-2 flex items-center gap-3">
+            <div className="flex h-1.5 flex-1 overflow-hidden bg-muted">
+              <span
+                className="bg-success"
+                style={{ width: `${(summary.complete / summary.total) * 100}%` }}
+              />
+              <span
+                className="bg-warning"
+                style={{ width: `${(summary.active / summary.total) * 100}%` }}
+              />
+            </div>
+            <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+              <b className="font-semibold text-foreground">{summary.complete}</b> done
+              {" · "}
+              <b className="font-semibold text-foreground">{summary.active}</b> in progress
+              {" · "}
+              <b className="font-semibold text-foreground">{summary.todo}</b> to do
+            </span>
+          </div>
+        )}
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {isLoading ? (
+          <div className="flex flex-col gap-2 p-3">
+            <Skeleton className="h-9" />
+            <Skeleton className="h-9" />
+            <Skeleton className="h-9" />
+          </div>
+        ) : (
+          <div>
+            {addingCustom && (
+              <div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2">
+                <Input
+                  autoFocus
+                  value={customLabel}
+                  onChange={(e) => setCustomLabel(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && customLabel.trim()) {
+                      addCustom.mutate(customLabel.trim())
+                    } else if (e.key === "Escape") {
+                      setAddingCustom(false)
+                      setCustomLabel("")
+                    }
+                  }}
+                  placeholder="Custom item name…"
+                  className="h-7"
+                />
+                <Button
+                  size="sm"
+                  disabled={!customLabel.trim() || addCustom.isPending}
+                  onClick={() => addCustom.mutate(customLabel.trim())}
+                >
+                  Add
+                </Button>
+              </div>
+            )}
+
+            {data?.groups.map((group) => (
+              <ChecklistGroupSection
+                key={group.key}
+                caseId={caseId}
+                label={group.label}
+                items={group.items}
+                showNa={showNa}
+                expandedKey={expandedKey}
+                setExpandedKey={setExpandedKey}
+                onChanged={invalidate}
+              />
+            ))}
+
+            {data && data.custom_items.length > 0 && (
+              <ChecklistGroupSection
+                caseId={caseId}
+                label="Other"
+                items={data.custom_items}
+                showNa={showNa}
+                expandedKey={expandedKey}
+                setExpandedKey={setExpandedKey}
+                onChanged={invalidate}
+              />
+            )}
+
+            {naCount > 0 && (
+              <div className="border-t px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => setShowNa((v) => !v)}
+                  className="text-[11px] text-muted-foreground hover:text-foreground"
+                >
+                  {showNa ? "Hide" : "Show"} N/A ({naCount})
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+interface GroupSectionProps {
+  caseId: number
+  label: string
+  items: ChecklistItem[]
+  showNa: boolean
+  expandedKey: string | null
+  setExpandedKey: (k: string | null) => void
+  onChanged: () => void
+}
+
+function ChecklistGroupSection({
+  caseId,
+  label,
+  items,
+  showNa,
+  expandedKey,
+  setExpandedKey,
+  onChanged,
+}: GroupSectionProps) {
+  const visible = items.filter((i) => showNa || i.status !== "na")
+  if (visible.length === 0) return null
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 px-3 pb-1 pt-2.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+        <span className="bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
+          {visible.length}
+        </span>
+      </div>
+      {visible.map((item) => (
+        <ChecklistRow
+          key={item.key}
+          caseId={caseId}
+          item={item}
+          expanded={expandedKey === item.key}
+          onToggle={() =>
+            setExpandedKey(expandedKey === item.key ? null : item.key)
+          }
+          onChanged={onChanged}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface ChecklistRowProps {
+  caseId: number
+  item: ChecklistItem
+  expanded: boolean
+  onToggle: () => void
+  onChanged: () => void
+}
+
+function ChecklistRow({ caseId, item, expanded, onToggle, onChanged }: ChecklistRowProps) {
+  const meta = CHECKLIST_STATUS_META[item.status]
+  const isComplete = item.status === "complete"
+  const isPartial = item.status === "partial"
+
+  return (
+    <div
+      className={cn(
+        "border-t",
+        expanded && "border-l-2 border-l-warning bg-muted/20"
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/30"
+      >
+        <StatusDot status={item.status} />
+        <div className="min-w-0 flex-1">
+          <div
+            className={cn(
+              "truncate text-[13px] font-medium",
+              isComplete && "font-normal text-muted-foreground"
+            )}
+          >
+            {item.label}
+          </div>
+          {item.notes && (
+            <div
+              className={cn(
+                "truncate text-[11px]",
+                isPartial ? "text-warning" : "text-muted-foreground"
+              )}
+            >
+              {item.notes}
+            </div>
+          )}
+        </div>
+        {item.comment_count > 0 && (
+          <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+            {item.comment_count}↳
+          </span>
+        )}
+        <span
+          className={cn(
+            "shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            STATUS_BADGE[item.status]
+          )}
+        >
+          {meta.label}
+        </span>
+      </button>
+
+      {expanded && (
+        <ExpandedItem caseId={caseId} item={item} onChanged={onChanged} />
+      )}
+    </div>
+  )
+}
+
+function StatusDot({ status }: { status: ChecklistStatus }) {
+  if (status === "complete") {
+    return (
+      <HugeiconsIcon
+        icon={CheckmarkCircle02Icon}
+        className="size-4 shrink-0 text-success"
+      />
+    )
+  }
+  if (status === "needed") {
+    return <span className="size-2.5 shrink-0 border border-muted-foreground/50" />
+  }
+  const tone =
+    status === "partial"
+      ? "bg-warning"
+      : status === "in_progress"
+      ? "bg-info"
+      : "bg-muted-foreground/40"
+  return <span className={cn("size-2.5 shrink-0", tone)} />
+}
+
+interface ExpandedItemProps {
+  caseId: number
+  item: ChecklistItem
+  onChanged: () => void
+}
+
+function ExpandedItem({ caseId, item, onChanged }: ExpandedItemProps) {
+  const queryClient = useQueryClient()
+  const [notes, setNotes] = useState(item.notes ?? "")
+  const [update, setUpdate] = useState("")
+
+  const setItem = useMutation({
+    mutationFn: (patch: { status?: ChecklistStatus; notes?: string | null }) =>
+      setChecklistItem(caseId, item.key, patch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["checklist-comments", caseId, item.key] })
+      onChanged()
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const removeItem = useMutation({
+    mutationFn: () => deleteChecklistItem(caseId, item.key),
+    onSuccess: onChanged,
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const { data: comments, isLoading: commentsLoading } = useQuery({
+    queryKey: ["checklist-comments", caseId, item.key],
+    queryFn: () => getChecklistComments(caseId, item.key),
+  })
+
+  const addUpdate = useMutation({
+    mutationFn: (content: string) => addChecklistComment(caseId, item.key, content),
+    onSuccess: () => {
+      setUpdate("")
+      queryClient.invalidateQueries({ queryKey: ["checklist-comments", caseId, item.key] })
+      onChanged()
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const notesDirty = (notes.trim() || null) !== (item.notes || null)
+
+  return (
+    <div className="flex flex-col gap-4 px-3 pb-4 pt-1">
+      {/* Status segmented control */}
+      <div>
+        <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Status
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {CHECKLIST_STATUS_ORDER.map((s) => {
+            const active = item.status === s
+            return (
+              <button
+                key={s}
+                type="button"
+                disabled={setItem.isPending}
+                onClick={() => !active && setItem.mutate({ status: s })}
+                className={cn(
+                  "border px-2.5 py-1 text-[11px] font-medium",
+                  active
+                    ? STATUS_BADGE[s] + " border-transparent"
+                    : "border-border text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {CHECKLIST_STATUS_META[s].label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Current-status one-liner */}
+      <div>
+        <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Current status
+        </div>
+        <Textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          onBlur={() => {
+            if (notesDirty) setItem.mutate({ notes: notes.trim() || null })
+          }}
+          placeholder="Short summary of where this stands…"
+          className="min-h-[38px] text-[12px]"
+          rows={2}
+        />
+      </div>
+
+      {/* Activity log */}
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Activity
+          </span>
+          {item.custom && (
+            <button
+              type="button"
+              onClick={() => removeItem.mutate()}
+              className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-destructive"
+            >
+              <HugeiconsIcon icon={Delete01Icon} className="size-3" />
+              Remove item
+            </button>
+          )}
+        </div>
+
+        {commentsLoading ? (
+          <Skeleton className="h-10" />
+        ) : comments && comments.length > 0 ? (
+          <div className="flex flex-col">
+            {comments.map((c) => (
+              <div key={c.id} className="flex gap-2.5 border-t py-2 first:border-t-0">
+                <div
+                  className={cn(
+                    "flex size-6 shrink-0 items-center justify-center text-[9px] font-bold",
+                    c.is_system
+                      ? "bg-muted text-muted-foreground"
+                      : "bg-primary text-primary-foreground"
+                  )}
+                >
+                  {c.is_system ? "↻" : c.user_initials || "?"}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-[10px] text-muted-foreground">
+                    <span className="font-semibold text-foreground">
+                      {[c.user_first_name, c.user_last_name].filter(Boolean).join(" ") ||
+                        "System"}
+                    </span>{" "}
+                    · {timeAgo(c.created_at)}
+                  </div>
+                  <div
+                    className={cn(
+                      "text-[12px] leading-relaxed",
+                      c.is_system && "italic text-muted-foreground"
+                    )}
+                  >
+                    {c.content}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[11px] text-muted-foreground">No updates yet.</p>
+        )}
+
+        <form
+          className="mt-2 flex items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault()
+            const t = update.trim()
+            if (t) addUpdate.mutate(t)
+          }}
+        >
+          <Input
+            value={update}
+            onChange={(e) => setUpdate(e.target.value)}
+            placeholder="Add an update…"
+            className="h-8 text-[12px]"
+          />
+          <Button
+            type="submit"
+            size="icon-sm"
+            disabled={!update.trim() || addUpdate.isPending}
+          >
+            <HugeiconsIcon icon={SentIcon} className="size-3.5" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/cases/components/case-document-tracker.tsx
+++ b/frontend/src/pages/cases/components/case-document-tracker.tsx
@@ -30,6 +30,12 @@ import {
   CardAction,
 } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -265,7 +271,6 @@ interface ChecklistRowProps {
 }
 
 function ChecklistRow({ caseId, item, expanded, onToggle, onChanged }: ChecklistRowProps) {
-  const meta = CHECKLIST_STATUS_META[item.status]
   const isComplete = item.status === "complete"
   const isPartial = item.status === "partial"
 
@@ -276,51 +281,104 @@ function ChecklistRow({ caseId, item, expanded, onToggle, onChanged }: Checklist
         expanded && "border-l-2 border-l-warning bg-muted/20"
       )}
     >
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/30"
-      >
-        <StatusDot status={item.status} />
-        <div className="min-w-0 flex-1">
-          <div
-            className={cn(
-              "truncate text-[13px] font-medium",
-              isComplete && "font-normal text-muted-foreground"
-            )}
-          >
-            {item.label}
-          </div>
-          {item.notes && (
+      <div className="flex items-center gap-2 pr-3">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 items-center gap-3 py-2 pl-3 text-left hover:bg-muted/30"
+        >
+          <StatusDot status={item.status} />
+          <div className="min-w-0 flex-1">
             <div
               className={cn(
-                "truncate text-[11px]",
-                isPartial ? "text-warning" : "text-muted-foreground"
+                "truncate text-[13px] font-medium",
+                isComplete && "font-normal text-muted-foreground"
               )}
             >
-              {item.notes}
+              {item.label}
             </div>
+            {item.notes && (
+              <div
+                className={cn(
+                  "truncate text-[11px]",
+                  isPartial ? "text-warning" : "text-muted-foreground"
+                )}
+              >
+                {item.notes}
+              </div>
+            )}
+          </div>
+          {item.comment_count > 0 && (
+            <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+              {item.comment_count}↳
+            </span>
           )}
-        </div>
-        {item.comment_count > 0 && (
-          <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
-            {item.comment_count}↳
-          </span>
-        )}
-        <span
-          className={cn(
-            "shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-            STATUS_BADGE[item.status]
-          )}
-        >
-          {meta.label}
-        </span>
-      </button>
+        </button>
+
+        <StatusChip caseId={caseId} item={item} onChanged={onChanged} />
+      </div>
 
       {expanded && (
         <ExpandedItem caseId={caseId} item={item} onChanged={onChanged} />
       )}
     </div>
+  )
+}
+
+interface StatusChipProps {
+  caseId: number
+  item: ChecklistItem
+  onChanged: () => void
+}
+
+/**
+ * The collapsed-row status pill, doubling as a quick-change control: click it
+ * to pick a new status from a dropdown without expanding the item.
+ */
+function StatusChip({ caseId, item, onChanged }: StatusChipProps) {
+  const queryClient = useQueryClient()
+  const meta = CHECKLIST_STATUS_META[item.status]
+
+  const setStatus = useMutation({
+    mutationFn: (status: ChecklistStatus) =>
+      setChecklistItem(caseId, item.key, { status }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["checklist-comments", caseId, item.key],
+      })
+      onChanged()
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={setStatus.isPending}
+          className={cn(
+            "shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide transition-opacity hover:opacity-80 disabled:opacity-50",
+            STATUS_BADGE[item.status]
+          )}
+        >
+          {meta.label}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[150px]">
+        {CHECKLIST_STATUS_ORDER.map((s) => (
+          <DropdownMenuItem
+            key={s}
+            disabled={s === item.status}
+            onSelect={() => setStatus.mutate(s)}
+            className="gap-2 text-[12px]"
+          >
+            <StatusDot status={s} />
+            {CHECKLIST_STATUS_META[s].label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/frontend/src/pages/cases/components/case-document-tracker.tsx
+++ b/frontend/src/pages/cases/components/case-document-tracker.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   Add01Icon,
+  ArrowDown01Icon,
+  ArrowRight01Icon,
   CheckmarkCircle02Icon,
   Delete01Icon,
   SentIcon,
@@ -97,7 +99,12 @@ export function CaseDocumentTracker({ caseId }: CaseDocumentTrackerProps) {
     return { total: visible.length, complete, active, todo }
   }, [allItems])
 
-  const naCount = allItems.filter((i) => i.status === "na").length
+  // All N/A items, regardless of which catalog group they came from, are
+  // pulled out of their groups and collected into one collapsible bucket.
+  const naItems = useMemo(
+    () => allItems.filter((i) => i.status === "na"),
+    [allItems]
+  )
 
   return (
     <Card size="sm">
@@ -179,7 +186,6 @@ export function CaseDocumentTracker({ caseId }: CaseDocumentTrackerProps) {
                 caseId={caseId}
                 label={group.label}
                 items={group.items}
-                showNa={showNa}
                 expandedKey={expandedKey}
                 setExpandedKey={setExpandedKey}
                 onChanged={invalidate}
@@ -191,22 +197,41 @@ export function CaseDocumentTracker({ caseId }: CaseDocumentTrackerProps) {
                 caseId={caseId}
                 label="Other"
                 items={data.custom_items}
-                showNa={showNa}
                 expandedKey={expandedKey}
                 setExpandedKey={setExpandedKey}
                 onChanged={invalidate}
               />
             )}
 
-            {naCount > 0 && (
-              <div className="border-t px-3 py-2">
+            {naItems.length > 0 && (
+              <div className="border-t">
                 <button
                   type="button"
                   onClick={() => setShowNa((v) => !v)}
-                  className="text-[11px] text-muted-foreground hover:text-foreground"
+                  className="flex w-full items-center gap-1.5 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
                 >
-                  {showNa ? "Hide" : "Show"} N/A ({naCount})
+                  <HugeiconsIcon
+                    icon={showNa ? ArrowDown01Icon : ArrowRight01Icon}
+                    className="size-3"
+                  />
+                  N/A
+                  <span className="bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
+                    {naItems.length}
+                  </span>
                 </button>
+                {showNa &&
+                  naItems.map((item) => (
+                    <ChecklistRow
+                      key={item.key}
+                      caseId={caseId}
+                      item={item}
+                      expanded={expandedKey === item.key}
+                      onToggle={() =>
+                        setExpandedKey(expandedKey === item.key ? null : item.key)
+                      }
+                      onChanged={invalidate}
+                    />
+                  ))}
               </div>
             )}
           </div>
@@ -220,7 +245,6 @@ interface GroupSectionProps {
   caseId: number
   label: string
   items: ChecklistItem[]
-  showNa: boolean
   expandedKey: string | null
   setExpandedKey: (k: string | null) => void
   onChanged: () => void
@@ -230,12 +254,12 @@ function ChecklistGroupSection({
   caseId,
   label,
   items,
-  showNa,
   expandedKey,
   setExpandedKey,
   onChanged,
 }: GroupSectionProps) {
-  const visible = items.filter((i) => showNa || i.status !== "na")
+  // N/A items live in their own bucket at the end, never inline in a group.
+  const visible = items.filter((i) => i.status !== "na")
   if (visible.length === 0) return null
 
   return (

--- a/frontend/src/pages/cases/components/case-features-menu.tsx
+++ b/frontend/src/pages/cases/components/case-features-menu.tsx
@@ -29,7 +29,7 @@ export function CaseFeaturesMenu({ caseData }: CaseFeaturesMenuProps) {
   const queryClient = useQueryClient()
   const toggles = caseData.feature_toggles ?? {}
   const counts = caseData.feature_data_counts ?? {
-    tasks: 0, events: 0, financials: 0, costs: 0,
+    tasks: 0, events: 0, financials: 0, costs: 0, documents: 0,
   }
 
   const mutation = useMutation({

--- a/frontend/src/pages/cases/detail.tsx
+++ b/frontend/src/pages/cases/detail.tsx
@@ -32,6 +32,7 @@ import { CaseTasksCard } from "@/pages/cases/components/case-tasks-card"
 import { AddTaskDialog } from "@/pages/cases/components/add-task-dialog"
 import { CaseEventsCard } from "@/pages/cases/components/case-events-card"
 import { AddEventDialog } from "@/pages/cases/components/add-event-dialog"
+import { CaseDocumentTracker } from "@/pages/cases/components/case-document-tracker"
 import { CaseKeyDates } from "@/pages/cases/components/case-key-dates"
 import { CaseNotesPanel } from "@/pages/cases/components/case-notes-panel"
 import { CaseFinancialsCard } from "@/pages/cases/components/case-financials-card"
@@ -213,6 +214,7 @@ function CaseDetailContent() {
   const showTasks = isCaseFeatureEnabled(toggles, "tasks")
   const showEvents = isCaseFeatureEnabled(toggles, "events")
   const showFinancials = isCaseFeatureEnabled(toggles, "financials")
+  const showDocuments = isCaseFeatureEnabled(toggles, "documents")
   const userHasInvoicesFeature =
     user?.visibleFeatures == null || user.visibleFeatures.includes("invoices")
   const showCosts = isCaseFeatureEnabled(toggles, "costs") && userHasInvoicesFeature
@@ -272,6 +274,7 @@ function CaseDetailContent() {
                 onAiAdd={() => setAiEventsOpen(true)}
               />
             )}
+            {showDocuments && <CaseDocumentTracker caseId={caseData.id} />}
             <CaseNotesPanel caseId={caseData.id} notes={caseData.notes} />
             {showFinancials && (
               <CaseFinancialsCard caseId={caseData.id} casePersons={caseData.persons} />

--- a/frontend/src/services/checklist.ts
+++ b/frontend/src/services/checklist.ts
@@ -1,0 +1,76 @@
+import { apiFetch } from "@/lib/api"
+import type { Checklist, ChecklistItem, ChecklistStatus } from "@/types/checklist"
+import type { Comment } from "@/services/comments"
+
+export async function getChecklist(caseId: number): Promise<Checklist> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/checklist`)
+  if (!res.ok) throw new Error("Failed to load document checklist")
+  return res.json()
+}
+
+export async function setChecklistItem(
+  caseId: number,
+  itemKey: string,
+  patch: { status?: ChecklistStatus; notes?: string | null }
+): Promise<ChecklistItem> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/checklist/item`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ item_key: itemKey, ...patch }),
+  })
+  if (!res.ok) throw new Error("Failed to update item")
+  const data = await res.json()
+  return data.item
+}
+
+export async function addCustomChecklistItem(
+  caseId: number,
+  label: string
+): Promise<ChecklistItem> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/checklist/custom`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ label }),
+  })
+  if (!res.ok) throw new Error("Failed to add item")
+  const data = await res.json()
+  return data.item
+}
+
+export async function deleteChecklistItem(
+  caseId: number,
+  itemKey: string
+): Promise<void> {
+  const res = await apiFetch(
+    `/api/v1/cases/${caseId}/checklist/item?key=${encodeURIComponent(itemKey)}`,
+    { method: "DELETE" }
+  )
+  if (!res.ok) throw new Error("Failed to remove item")
+}
+
+export async function getChecklistComments(
+  caseId: number,
+  itemKey: string
+): Promise<Comment[]> {
+  const res = await apiFetch(
+    `/api/v1/cases/${caseId}/checklist/comments?key=${encodeURIComponent(itemKey)}`
+  )
+  if (!res.ok) throw new Error("Failed to load activity")
+  const data = await res.json()
+  return data.comments
+}
+
+export async function addChecklistComment(
+  caseId: number,
+  itemKey: string,
+  content: string
+): Promise<Comment> {
+  const res = await apiFetch(`/api/v1/cases/${caseId}/checklist/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ item_key: itemKey, content }),
+  })
+  if (!res.ok) throw new Error("Failed to post update")
+  const data = await res.json()
+  return data.comment
+}

--- a/frontend/src/types/case.ts
+++ b/frontend/src/types/case.ts
@@ -91,7 +91,7 @@ export interface RepresentationLayout {
   rows: RepresentationRow[]
 }
 
-export type CaseFeatureKey = "tasks" | "events" | "financials" | "costs"
+export type CaseFeatureKey = "tasks" | "events" | "financials" | "costs" | "documents"
 
 export type CaseFeatureToggles = Partial<Record<CaseFeatureKey, boolean>>
 
@@ -102,6 +102,7 @@ export const CASE_FEATURE_DEFINITIONS: {
 }[] = [
   { key: "tasks", label: "Tasks", description: "Track to-dos on this case" },
   { key: "events", label: "Events", description: "Calendar dates and deadlines" },
+  { key: "documents", label: "Documents", description: "Intake document & authorization tracking" },
   { key: "financials", label: "Financials", description: "Settlement & disbursement summary" },
   { key: "costs", label: "Costs", description: "Costs/invoices link and totals" },
 ]

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -1,0 +1,51 @@
+export type ChecklistStatus =
+  | "needed"
+  | "in_progress"
+  | "partial"
+  | "complete"
+  | "na"
+
+export interface ChecklistItem {
+  /** Catalog key (e.g. "medical_records") or "custom:<id>" for user-added. */
+  key: string
+  label: string
+  status: ChecklistStatus
+  notes: string | null
+  /** Row id once materialized; null while the item is still a virtual default. */
+  id: number | null
+  comment_count: number
+  custom: boolean
+  updated_at: string | null
+}
+
+export interface ChecklistGroup {
+  key: string
+  label: string
+  items: ChecklistItem[]
+}
+
+export interface Checklist {
+  groups: ChecklistGroup[]
+  custom_items: ChecklistItem[]
+}
+
+/** Display metadata per status, keyed for the segmented control and pills. */
+export const CHECKLIST_STATUS_META: Record<
+  ChecklistStatus,
+  { label: string; tone: "muted" | "info" | "warning" | "success" }
+> = {
+  needed: { label: "To do", tone: "muted" },
+  in_progress: { label: "In progress", tone: "info" },
+  partial: { label: "Partial", tone: "warning" },
+  complete: { label: "Complete", tone: "success" },
+  na: { label: "N/A", tone: "muted" },
+}
+
+/** Order the segmented control presents statuses in. */
+export const CHECKLIST_STATUS_ORDER: ChecklistStatus[] = [
+  "needed",
+  "in_progress",
+  "partial",
+  "complete",
+  "na",
+]

--- a/models.py
+++ b/models.py
@@ -329,6 +329,7 @@ class Case(Base):
 
     # Relationships
     comments: Mapped[list[CaseComment]] = relationship(back_populates="case", passive_deletes=True)
+    checklist_items: Mapped[list[CaseChecklistItem]] = relationship(back_populates="case", passive_deletes=True)
     events: Mapped[list[Event]] = relationship(back_populates="case", passive_deletes=True)
     financial: Mapped[Optional[CaseFinancial]] = relationship(back_populates="case", uselist=False, passive_deletes=True)
     intakes: Mapped[list[Intake]] = relationship(back_populates="case")
@@ -338,6 +339,56 @@ class Case(Base):
     tasks: Mapped[list[Task]] = relationship(back_populates="case", passive_deletes=True)
     invoices: Mapped[list[Invoice]] = relationship(back_populates="case", passive_deletes=True)
     liens: Mapped[list[Lien]] = relationship(back_populates="case", passive_deletes=True)
+
+
+class CaseChecklistItem(Base):
+    """A tracked intake document or authorization for a case.
+
+    The catalog of standard items (the two groups — authorizations and
+    documents) lives in code (db/checklist.py); rows here are created lazily
+    only when an item is actually acted on (status moved off the default,
+    notes added, a comment posted, or a custom item created). Untouched
+    catalog items are virtual and have no row — so enabling the Documents
+    section on a case never materializes rows, keeping the feature toggle
+    freely reversible.
+
+    The per-item activity log reuses the polymorphic `comments` table with
+    entity_type="checklist_item" and entity_id=this row's id.
+    """
+
+    __tablename__ = "case_checklist_items"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["case_id"], ["cases.id"], ondelete="CASCADE",
+            name="case_checklist_items_case_id_fkey",
+        ),
+        PrimaryKeyConstraint("id", name="case_checklist_items_pkey"),
+        UniqueConstraint(
+            "case_id", "item_key", name="uq_case_checklist_items_case_key"
+        ),
+        Index("idx_case_checklist_items_case_id", "case_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    case_id: Mapped[int] = mapped_column(Integer)
+    # Catalog key (e.g. "signed_retainer") or "custom:<uuid>" for user-added.
+    item_key: Mapped[str] = mapped_column(String(60))
+    # Only set for custom items; standard items take their label from the catalog.
+    label: Mapped[Optional[str]] = mapped_column(String(120))
+    # One of: needed | in_progress | partial | complete | na
+    status: Mapped[str] = mapped_column(
+        String(20), server_default=text("'needed'::character varying")
+    )
+    notes: Mapped[Optional[str]] = mapped_column(Text)
+    sort_order: Mapped[Optional[int]] = mapped_column(Integer)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=text("CURRENT_TIMESTAMP")
+    )
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=text("CURRENT_TIMESTAMP")
+    )
+
+    case: Mapped[Case] = relationship(back_populates="checklist_items")
 
 
 class ExpertiseType(Base):

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -60,6 +60,7 @@ from .health import register_health_routes
 from .activity import register_activity_routes
 from .contacts import register_contact_routes
 from .comments import register_comment_routes
+from .checklist import register_checklist_routes
 from .trial_calendar import register_trial_calendar_routes
 from .dale import register_dale_routes
 from .alerts import register_alert_routes
@@ -140,6 +141,8 @@ def register_routes(mcp):
     register_contact_routes(mcp)
     _logger.debug("Registering comment routes...")
     register_comment_routes(mcp)
+    _logger.debug("Registering checklist routes...")
+    register_checklist_routes(mcp)
     _logger.debug("Registering trial calendar routes...")
     register_trial_calendar_routes(mcp)
     _logger.debug("Registering Dale routes...")

--- a/routes/checklist.py
+++ b/routes/checklist.py
@@ -1,0 +1,161 @@
+"""
+Document-tracking checklist routes (the "Document Tracking" card).
+
+All endpoints are scoped to a case and gated behind the case's `documents`
+feature toggle. The per-item activity log is the polymorphic comment system
+(entity_type="checklist_item"), reached here via db.checklist helpers so the
+frontend only ever deals in item keys.
+
+Endpoints:
+    GET    /api/v1/cases/{case_id}/checklist
+    PUT    /api/v1/cases/{case_id}/checklist/item        body: {item_key, status?, notes?}
+    POST   /api/v1/cases/{case_id}/checklist/custom      body: {label}
+    DELETE /api/v1/cases/{case_id}/checklist/item?key=…
+    GET    /api/v1/cases/{case_id}/checklist/comments?key=…
+    POST   /api/v1/cases/{case_id}/checklist/comments    body: {item_key, content}
+"""
+
+import asyncio
+from fastapi.responses import JSONResponse
+
+import auth
+import db
+from db.feature_gates import require_feature_for_case, FEATURE_DOCUMENTS, FeatureDisabled
+from .common import api_error, feature_disabled_error
+from .comments import _get_db_user_id
+from .sse import broadcast
+
+
+def register_checklist_routes(mcp):
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist", methods=["GET"])
+    async def api_get_checklist(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        data = await asyncio.to_thread(db.get_checklist, case_id)
+        return JSONResponse(data)
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist/item", methods=["PUT"])
+    async def api_set_checklist_item(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        user = auth.get_current_user(request)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return api_error("Invalid JSON body", "VALIDATION_ERROR", 400)
+        item_key = body.get("item_key")
+        if not item_key:
+            return api_error("item_key is required", "VALIDATION_ERROR", 400)
+
+        try:
+            await asyncio.to_thread(_require_documents, case_id)
+        except FeatureDisabled as e:
+            return feature_disabled_error(e)
+
+        result = await asyncio.to_thread(
+            db.set_checklist_item,
+            case_id,
+            item_key,
+            status=body.get("status"),
+            notes=body.get("notes"),
+            user_id=_get_db_user_id(user),
+        )
+        if result is None:
+            return api_error("Unknown checklist item or status", "VALIDATION_ERROR", 400)
+        broadcast({"entity": "checklist", "action": "updated", "case_id": case_id})
+        return JSONResponse({"item": result})
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist/custom", methods=["POST"])
+    async def api_add_custom_checklist_item(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+
+        try:
+            body = await request.json()
+        except Exception:
+            return api_error("Invalid JSON body", "VALIDATION_ERROR", 400)
+        label = (body.get("label") or "").strip()
+        if not label:
+            return api_error("label is required", "VALIDATION_ERROR", 400)
+
+        try:
+            await asyncio.to_thread(_require_documents, case_id)
+        except FeatureDisabled as e:
+            return feature_disabled_error(e)
+
+        result = await asyncio.to_thread(db.add_checklist_custom_item, case_id, label)
+        broadcast({"entity": "checklist", "action": "updated", "case_id": case_id})
+        return JSONResponse({"item": result})
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist/item", methods=["DELETE"])
+    async def api_delete_checklist_item(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        item_key = request.query_params.get("key")
+        if not item_key:
+            return api_error("key query param is required", "VALIDATION_ERROR", 400)
+
+        try:
+            await asyncio.to_thread(_require_documents, case_id)
+        except FeatureDisabled as e:
+            return feature_disabled_error(e)
+
+        ok = await asyncio.to_thread(db.delete_checklist_item, case_id, item_key)
+        broadcast({"entity": "checklist", "action": "updated", "case_id": case_id})
+        return JSONResponse({"success": ok})
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist/comments", methods=["GET"])
+    async def api_get_checklist_comments(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        item_key = request.query_params.get("key")
+        if not item_key:
+            return api_error("key query param is required", "VALIDATION_ERROR", 400)
+        comments = await asyncio.to_thread(db.get_checklist_item_comments, case_id, item_key)
+        return JSONResponse({"comments": comments})
+
+    @mcp.custom_route("/api/v1/cases/{case_id}/checklist/comments", methods=["POST"])
+    async def api_add_checklist_comment(request):
+        if err := auth.require_auth(request):
+            return err
+        case_id = int(request.path_params["case_id"])
+        user = auth.get_current_user(request)
+        if not user:
+            return api_error("User not found", "UNAUTHORIZED", 401)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return api_error("Invalid JSON body", "VALIDATION_ERROR", 400)
+        item_key = body.get("item_key")
+        content = (body.get("content") or "").strip()
+        if not item_key or not content:
+            return api_error("item_key and content are required", "VALIDATION_ERROR", 400)
+
+        try:
+            await asyncio.to_thread(_require_documents, case_id)
+        except FeatureDisabled as e:
+            return feature_disabled_error(e)
+
+        comment = await asyncio.to_thread(
+            db.add_checklist_item_comment, case_id, item_key, _get_db_user_id(user), content
+        )
+        if comment is None:
+            return api_error("Unknown checklist item", "VALIDATION_ERROR", 400)
+        broadcast({"entity": "checklist", "action": "commented", "case_id": case_id})
+        return JSONResponse({"comment": comment})
+
+
+def _require_documents(case_id: int) -> None:
+    """Raise FeatureDisabled if the Documents section is off for this case."""
+    from db.session import SessionLocal
+
+    with SessionLocal() as session:
+        require_feature_for_case(session, case_id, FEATURE_DOCUMENTS)


### PR DESCRIPTION
## What this adds

A per-case **Document Tracking** card for tracking intake documents & authorizations, toggled on per case via the section gear menu (sits below Events, above Notes).

- **Catalog + lazy rows**: a fixed catalog of intake docs/authorizations (Authorizations, Documents groups) is overlaid with sparse per-case rows. Rows are only created when an item is acted on, so the `documents` feature toggle stays freely reversible until data exists (then it locks on, like Tasks/Financials).
- **Per-item status**: To do / In progress / Partial / Complete / N/A, with a current-status note and a per-item activity log (system entries on status change + free-text updates). Reuses the polymorphic `comments` table (`entity_type="checklist_item"`).
- **Quick-status chips**: the status pill on each collapsed row is a dropdown — change status directly without expanding.
- **N/A bucket**: N/A items are pulled out of their groups into a single collapsible "N/A (n)" section at the end; collapsed by default, rows stay interactive so un-N/A'ing returns an item to its group.
- **Progress summary**: top bar + "X done · Y in progress · Z to do".
- **Custom items**: "+ Item" adds user-defined entries under an "Other" group; removable.

## Why

Gives intake/case staff a structured, per-case checklist for the documents and authorizations a case needs, replacing the firm's paper "Client Information Sheet" checklists.

## Reviewer notes

- **DB migration** `f7a1c9e4d2b8` adds the `case_checklist_items` table. It's additive (new table only) and runs automatically on deploy via the Dockerfile `alembic upgrade head` step.
- **No new MCP tools** — this is web-UI-only, so `MCP_INSTRUCTIONS` is unchanged. No new root-level `.py` files, so `Dockerfile` COPY lines are unchanged.
- **Two dev-only helper files are included** (`.claude/launch.json`, `frontend/dev-node20.sh`) — they let the preview/IDE tooling launch the Vite dev server on the right Node version + proxy port. They're not referenced by the Dockerfile or any runtime code, so they have zero effect on the deployed app. Drop them from the merge if you'd rather keep them off main.

## Testing

- Verified end-to-end locally (status changes, N/A bucket, custom items, toggle lock, activity log) and on the staging branch. Migration applies cleanly; `alembic check` reports no drift; frontend `tsc -b` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)