### PR TITLE
feat(worklog): weekday + clearer Today control, and first-class 'No case / General'

### DIFF
--- a/db/worklog.py
+++ b/db/worklog.py
@@ -391,6 +391,10 @@ def update_worklog_entry(entry_id: int, fields: dict, user_id: Optional[int]) ->
             return None
         if "case_id" in fields:
             entry.case_id = fields["case_id"]
+            # The user explicitly resolved the assignment — to a case or to
+            # "General" (null). Either way, drop the AI's unmatched guess so the
+            # entry stops showing the dashed "unmatched" chip.
+            entry.raw_reference = None
         if "hours" in fields and fields["hours"] is not None:
             entry.hours = _norm_hours(fields["hours"])
         if "description" in fields and fields["description"] is not None:

--- a/frontend/src/pages/worklog/components/worklog-pickers.tsx
+++ b/frontend/src/pages/worklog/components/worklog-pickers.tsx
@@ -1,7 +1,5 @@
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { HugeiconsIcon } from "@hugeicons/react"
-import { Add01Icon, Cancel01Icon } from "@hugeicons/core-free-icons"
 import { getCases } from "@/services/cases"
 import type { CaseListItem } from "@/types/case"
 import { Badge } from "@/components/ui/badge"
@@ -11,9 +9,14 @@ import { getBadgeStyle } from "@/lib/badge-colors"
 import { cn } from "@/lib/utils"
 
 /**
- * Compact case selector: a colored case chip (or an "unmatched"/"+ case" hint)
- * that opens a searchable popover. Mirrors the case badge used in task/event
- * lists. Calls onChange with the picked case id (or null to clear).
+ * Compact case selector. The trigger shows one of three states:
+ *   - a colored case chip when matched to a case,
+ *   - a dashed "unmatched" chip when the AI couldn't match a referenced case
+ *     (`guess` present) — needs the user's attention,
+ *   - a neutral "General" chip when the entry intentionally has no case.
+ * The popover offers "No case (general)" as a first-class choice alongside the
+ * searchable case list. onChange fires with the picked case id, or null for
+ * General / no case.
  */
 export function InlineCasePicker({
   value,
@@ -76,9 +79,8 @@ export function InlineCasePicker({
               {guess}
             </Badge>
           ) : (
-            <span className="inline-flex h-4 items-center gap-0.5 border border-dashed border-muted-foreground/30 px-1.5 text-[10px] text-muted-foreground/60 transition-colors hover:border-muted-foreground/60 hover:text-muted-foreground">
-              <HugeiconsIcon icon={Add01Icon} className="size-2.5" />
-              case
+            <span className="inline-flex h-4 items-center border bg-muted/60 px-1.5 text-[10px] leading-none text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
+              General
             </span>
           )}
         </button>
@@ -94,16 +96,19 @@ export function InlineCasePicker({
           />
         </div>
         <div className="max-h-56 overflow-auto p-1">
-          {value && (
-            <button
-              type="button"
-              onClick={() => { onChange(null); setOpen(false) }}
-              className="flex w-full items-center gap-1.5 px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/50"
-            >
-              <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
-              Clear case
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => { onChange(null); setOpen(false) }}
+            className={cn(
+              "mb-1 flex w-full items-center gap-2 border-b px-2 py-1.5 text-left hover:bg-accent/50",
+              value === null && !guess && "bg-accent/40"
+            )}
+          >
+            <span className="inline-flex h-4 shrink-0 items-center border bg-muted/60 px-1.5 text-[10px] leading-none text-muted-foreground">
+              General
+            </span>
+            <span className="truncate text-[11px] text-muted-foreground">No case — general work</span>
+          </button>
           {filtered.map((c) => (
             <button
               key={c.id}

--- a/frontend/src/pages/worklog/index.tsx
+++ b/frontend/src/pages/worklog/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { PenTool01Icon, ArrowLeft01Icon, ArrowRight01Icon, Add01Icon } from "@hugeicons/core-free-icons"
+import { PenTool01Icon, ArrowLeft01Icon, ArrowRight01Icon, Add01Icon, Target01Icon, Tick02Icon } from "@hugeicons/core-free-icons"
 import { getWorklogDay, addWorklogEntry, formatHours } from "@/services/worklog"
 import { WorklogEntryRow } from "@/pages/worklog/components/worklog-entry-row"
 import { WorklogComposer } from "@/pages/worklog/components/worklog-composer"
@@ -21,6 +21,15 @@ function shiftDay(key: string, delta: number): string {
   const [y, m, d] = key.split("-").map(Number)
   const date = new Date(y, m - 1, d + delta)
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`
+}
+
+// "Today" / "Yesterday" / "Tomorrow" relative to the current day, or null.
+function relativeDayLabel(key: string): string | null {
+  const today = todayKey()
+  if (key === today) return "Today"
+  if (key === shiftDay(today, -1)) return "Yesterday"
+  if (key === shiftDay(today, 1)) return "Tomorrow"
+  return null
 }
 
 export default function WorklogPage() {
@@ -42,6 +51,8 @@ export default function WorklogPage() {
 
   const entries = day?.entries ?? []
   const isToday = dayKey === todayKey()
+  const weekday = formatLA(`${dayKey}T00:00:00`, { weekday: "long" })
+  const relative = relativeDayLabel(dayKey)
 
   return (
     <FeatureGate feature="log-my-day" redirectTo="/">
@@ -52,12 +63,16 @@ export default function WorklogPage() {
       </div>
 
       {/* Day navigator */}
-      <div className="flex items-center gap-2 mb-4">
+      <div className="flex items-start gap-2 mb-4">
         <Button variant="outline" size="icon-sm" onClick={() => setDayKey((k) => shiftDay(k, -1))} title="Previous day">
           <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
         </Button>
         <div className="w-44">
           <DatePicker value={dayKey} onChange={(d) => setDayKey(d ?? dayKey)} />
+          <p className="mt-1 px-1 text-xs text-muted-foreground">
+            {weekday}
+            {relative && relative !== "Today" && <span> · {relative}</span>}
+          </p>
         </div>
         <Button
           variant="outline"
@@ -68,12 +83,24 @@ export default function WorklogPage() {
         >
           <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
         </Button>
-        {!isToday && (
-          <Button variant="ghost" size="sm" className="text-xs" onClick={() => setDayKey(todayKey())}>
+        {isToday ? (
+          <span className="inline-flex h-8 items-center gap-1.5 border border-success/30 bg-success/10 px-2.5 text-xs font-medium text-success">
+            <HugeiconsIcon icon={Tick02Icon} className="size-3.5" />
             Today
+          </span>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs"
+            onClick={() => setDayKey(todayKey())}
+            title="Jump to today"
+          >
+            <HugeiconsIcon icon={Target01Icon} className="size-3.5" />
+            Jump to today
           </Button>
         )}
-        <span className="ml-auto text-sm">
+        <span className="ml-auto mt-1.5 text-sm">
           <span className="text-muted-foreground">Total </span>
           <span className="font-semibold tabular-nums">{formatHours(day?.total_hours ?? 0)}</span>
         </span>

--- a/services/worklog_consolidator.py
+++ b/services/worklog_consolidator.py
@@ -57,7 +57,10 @@ SUBMIT_WORKLOG_TOOL = {
                         },
                         "case_guess": {
                             "type": "string",
-                            "description": "How the user referred to the case (for unmatched display).",
+                            "description": (
+                                "How the user referred to a SPECIFIC case that couldn't be "
+                                "matched. Leave empty for general work that isn't about any case."
+                            ),
                         },
                         "person_ids": {
                             "type": "array",
@@ -66,10 +69,14 @@ SUBMIT_WORKLOG_TOOL = {
                         },
                         "raw_reference": {
                             "type": "string",
-                            "description": "The original phrasing for this activity.",
+                            "description": (
+                                "The user's original phrasing for this activity, but ONLY when it "
+                                "names a specific case that couldn't be matched. OMIT for general "
+                                "work with no case (it renders as a clean 'General' entry)."
+                            ),
                         },
                     },
-                    "required": ["description", "hours", "raw_reference"],
+                    "required": ["description", "hours"],
                 },
             }
         },
@@ -104,13 +111,18 @@ lengths; flexible work absorbs the remainder and is scaled to fit. If anchored i
 exceed 7h, keep them accurate and let the total exceed — the user will adjust. Never pad with
 invented activities; only distribute time across what's given.
 
-STEP 4 — MATCH each activity to a case (fuzzy by name). No confident case match -> case_id=null,
-put the user's phrasing in case_guess. ALWAYS fill raw_reference.
+STEP 4 — MATCH each activity to a case (fuzzy by name). Three outcomes:
+  (a) Confident match -> set case_id.
+  (b) The user named a SPECIFIC case but you can't match it -> case_id=null, put the user's
+      phrasing in case_guess and raw_reference (it shows as an "unmatched" chip to fix).
+  (c) General work that isn't about any single case (admin, intake review, CLE, firm meetings,
+      reviewing potential new matters, etc.) -> case_id=null and LEAVE case_guess / raw_reference
+      EMPTY. This is a valid "General" entry, not an error — do NOT invent a case reference for it.
 - DESCRIPTIONS: write the activity ONLY — never repeat the case name or party names in the
   description (the case is stored separately via case_id and shown as its own chip). Strip any
   "for <Case>" / "in <Case>" / "on the <Case> matter" phrasing. E.g. "Prepared discovery
-  responses", NOT "Prepared discovery responses for Brooks v. Vons Grocery". Keep raw_reference
-  intact (it preserves the original phrasing for unmatched display).
+  responses", NOT "Prepared discovery responses for Brooks v. Vons Grocery". For (b), keep
+  raw_reference intact (it preserves the original phrasing for unmatched display).
 - EXPLICITLY TAGGED CASES: if that list is provided, the user picked those cases by name and
   their exact case_name appears verbatim in the memo. When an activity's text contains a tagged
   case's name, you MUST use that exact case_id — do not second-guess or leave it null.


### PR DESCRIPTION
## Summary

Two worklog ("Log my day") improvements, tested working on staging.

### 1. Day navigator UI
- Shows the selected day's **weekday** beneath the date picker, with *Yesterday* / *Tomorrow* hints.
- Replaces the bare "Today" link with two explicit states:
  - a success-tinted **Today** badge when viewing today (clear you're on today)
  - a **Jump to today** button (target icon) otherwise (clear it zooms back)

### 2. "No case / General" as a first-class option
Previously, an entry with no case rendered as an unfilled `+ case` nag, and the AI was told to *always* fill `raw_reference` — so genuinely case-less work (admin, intake review, CLE, firm meetings) got flagged as "unmatched."

- The per-row case picker now offers an explicit **"No case — general work"** choice.
- No-case entries render as a deliberate neutral **General** chip instead of a TODO prompt.
- Resolving an entry (to a case *or* General) clears the AI's unmatched guess server-side.
- The consolidator now distinguishes three outcomes: matched / unmatched-but-referenced / genuinely general — and leaves `raw_reference` empty for general work.

The existing nullable `case_id` + `raw_reference` columns already encode the distinction, so **no DB migration** is required.

## Test plan
- [x] Frontend `tsc` passes (pre-push hook)
- [x] Manually verified on staging