### PR TITLE
Event tasks: associate tasks with events + worklog tweaks

### DIFF
--- a/db/tasks.py
+++ b/db/tasks.py
@@ -97,7 +97,7 @@ def add_task(case_id: int = None, description: str = "", due_date: str = None,
 def get_tasks(case_id: int = None, status_filter: str = None, exclude_status: str = None,
               urgency_filter: str = None, due_date_from: str = None, due_date_to: str = None,
               limit: int = None, offset: int = None, assignee_id: int = None,
-              user_id: int = None, intake_id: int = None) -> dict:
+              user_id: int = None, intake_id: int = None, event_id: int = None) -> dict:
     """Get tasks with optional filters."""
     # Validate filters
     if status_filter:
@@ -133,6 +133,8 @@ def get_tasks(case_id: int = None, status_filter: str = None, exclude_status: st
         stmt = stmt.where(Task.case_id == case_id)
     if intake_id:
         stmt = stmt.where(Task.intake_id == intake_id)
+    if event_id:
+        stmt = stmt.where(Task.event_id == event_id)
     stmt = stmt.where(feature_clause)
     if status_filter:
         stmt = stmt.where(Task.status == status_filter)
@@ -162,6 +164,8 @@ def get_tasks(case_id: int = None, status_filter: str = None, exclude_status: st
             count_base = count_base.where(Task.case_id == case_id)
         if intake_id:
             count_base = count_base.where(Task.intake_id == intake_id)
+        if event_id:
+            count_base = count_base.where(Task.event_id == event_id)
         count_base = count_base.where(feature_clause)
         if status_filter:
             count_base = count_base.where(Task.status == status_filter)

--- a/frontend/src/pages/events/components/event-detail-dialog.tsx
+++ b/frontend/src/pages/events/components/event-detail-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { getStaff } from "@/services/staff"
 import { InlineEditField } from "@/components/common/inline-edit-field"
 import { DetailDialogActions } from "@/components/common/detail-dialog-actions"
+import { EventTasksSection } from "@/pages/events/components/event-tasks-section"
 import { getBadgeStyle, getAvatarStyleById } from "@/lib/badge-colors"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -306,6 +307,9 @@ export function EventDetailDialog({
             )}
           </div>
         </div>
+
+        {/* Tasks */}
+        <EventTasksSection eventId={event.id} caseId={event.case_id ?? null} />
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/pages/events/components/event-tasks-section.tsx
+++ b/frontend/src/pages/events/components/event-tasks-section.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Add01Icon } from "@hugeicons/core-free-icons"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { getTasks, createTask, updateTask } from "@/services/tasks"
+import type { TaskListItem as TaskListItemType } from "@/types/task"
+import { TaskListItem } from "@/pages/tasks/components/task-list-item"
+import { TaskDetailDialog } from "@/pages/tasks/components/task-detail-dialog"
+
+interface EventTasksSectionProps {
+  eventId: number
+  /** Case the event belongs to — new tasks inherit it (null for case-less events) */
+  caseId: number | null
+}
+
+export function EventTasksSection({ eventId, caseId }: EventTasksSectionProps) {
+  const queryClient = useQueryClient()
+  const [selectedTask, setSelectedTask] = useState<TaskListItemType | null>(null)
+  const [newDescription, setNewDescription] = useState("")
+
+  const tasksKey = ["tasks", "event", eventId]
+
+  const { data } = useQuery({
+    queryKey: tasksKey,
+    queryFn: () => getTasks({ event_id: eventId, limit: 200 }),
+  })
+
+  const tasks = data?.tasks ?? []
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: tasksKey })
+    queryClient.invalidateQueries({ queryKey: ["tasks"] })
+    queryClient.invalidateQueries({ queryKey: ["event", eventId] })
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: ({ taskId, field, value }: { taskId: number; field: string; value: unknown }) =>
+      updateTask(taskId, { [field]: value }),
+    onSuccess: invalidate,
+    onError: (e) => toast.error(e.message),
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (description: string) =>
+      createTask({
+        description,
+        event_id: eventId,
+        case_id: caseId ?? undefined,
+        status: "Pending",
+      }),
+    onSuccess: () => {
+      setNewDescription("")
+      invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  function handleAdd() {
+    const desc = newDescription.trim()
+    if (!desc || createMutation.isPending) return
+    createMutation.mutate(desc)
+  }
+
+  return (
+    <div className="border-t pt-3">
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Tasks
+      </span>
+
+      <TooltipProvider delayDuration={300}>
+        <div className="mt-1.5 border border-border">
+          {tasks.length > 0 &&
+            tasks.map((task) => (
+              <TaskListItem
+                key={task.id}
+                task={task}
+                onTaskClick={setSelectedTask}
+                onUpdateTask={(taskId, field, value) =>
+                  updateMutation.mutate({ taskId, field, value })
+                }
+                hideCaseBadge
+                hideEventLinker
+              />
+            ))}
+
+          {/* Quick-add row */}
+          <div className="flex items-center gap-2 px-3 py-2">
+            <HugeiconsIcon
+              icon={Add01Icon}
+              className="size-4 shrink-0 text-muted-foreground/50"
+            />
+            <input
+              type="text"
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault()
+                  handleAdd()
+                }
+              }}
+              onBlur={handleAdd}
+              placeholder="Add a task..."
+              className="flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground/60"
+            />
+          </div>
+        </div>
+      </TooltipProvider>
+
+      <TaskDetailDialog
+        task={selectedTask}
+        open={!!selectedTask}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTask(null)
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/events/components/event-tasks-section.tsx
+++ b/frontend/src/pages/events/components/event-tasks-section.tsx
@@ -33,6 +33,8 @@ export function EventTasksSection({ eventId, caseId }: EventTasksSectionProps) {
     queryClient.invalidateQueries({ queryKey: tasksKey })
     queryClient.invalidateQueries({ queryKey: ["tasks"] })
     queryClient.invalidateQueries({ queryKey: ["event", eventId] })
+    // Refresh the events list so the task-count indicator updates
+    queryClient.invalidateQueries({ queryKey: ["events"] })
   }
 
   const updateMutation = useMutation({

--- a/frontend/src/pages/tasks/components/task-list-item.tsx
+++ b/frontend/src/pages/tasks/components/task-list-item.tsx
@@ -247,6 +247,8 @@ interface TaskListItemProps {
   onTaskClick: (task: TaskListItemType) => void
   onUpdateTask: (taskId: number, field: string, value: unknown) => void
   hideCaseBadge?: boolean
+  /** Hide the linked-event chip (e.g. when already inside an event context) */
+  hideEventLinker?: boolean
   showDone?: boolean
   unreadCount?: number
 }
@@ -398,6 +400,7 @@ export function TaskListItem({
   onTaskClick,
   onUpdateTask,
   hideCaseBadge,
+  hideEventLinker,
   showDone,
   unreadCount,
 }: TaskListItemProps) {
@@ -491,7 +494,7 @@ export function TaskListItem({
               </div>
 
               {/* Linked event — inline combobox (hidden on mobile) */}
-              {(task.has_events || task.case_id) && (
+              {!hideEventLinker && (task.has_events || task.case_id) && (
                 <span className="hidden sm:inline-flex">
                   <InlineEventLinker
                     task={task}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -59,6 +59,7 @@ export interface TaskDetail {
 export interface GetTasksParams {
   case_id?: number
   intake_id?: number
+  event_id?: number
   status?: TaskStatus
   exclude_status?: TaskStatus
   urgency?: Urgency

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -33,6 +33,7 @@ def register_task_routes(mcp):
         due_date_to = request.query_params.get("due_date_to")
         user_id = request.query_params.get("user_id")
         assignee_id = request.query_params.get("assignee_id")
+        event_id = request.query_params.get("event_id")
         limit, offset = clamp_pagination(request)
 
         result = await asyncio.to_thread(
@@ -48,6 +49,7 @@ def register_task_routes(mcp):
             user_id=int(user_id) if user_id else None,
             assignee_id=int(assignee_id) if assignee_id else None,
             intake_id=int(intake_id) if intake_id else None,
+            event_id=int(event_id) if event_id else None,
         )
         return JSONResponse(result)
 


### PR DESCRIPTION
## Summary

Surfaces the existing event↔task relationship in the UI.

- **Tasks section in the event detail modal** — lists all tasks linked to an event (any status) and provides an inline quick-add row that creates a `Pending` task linked to the event and its case. Reuses the compact `TaskListItem` controls (status, date, urgency, assignee); case badge and event linker are hidden as redundant in this context.
- **Backend** — `get_tasks()` / `GET /api/v1/tasks` gain an `event_id` filter.
- **List indicator** — the events list already rendered a `task_count` badge; fixed it to refresh immediately by invalidating the `["events"]` query when tasks change in the modal.

## Testing
- Verified the `event_id` filter end-to-end (create → filter isolates by event, other events unaffected).
- Drove the UI in the browser: quick-add, inline date picker, urgency, and the live-updating task-count badge on the list. DB persistence confirmed; no console errors. Test data cleaned up.

## Notes
- The `task_count` badge currently counts **all** tasks regardless of status. Counting only open (non-Done) tasks is a one-line change if preferred.