### PR TITLE
fix(frontend): auto-recover from stale-chunk errors after deploy

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,16 +11,45 @@ import LoginPage from "@/pages/login"
 
 import "./index.css"
 
+// A stale-chunk error happens when a new deploy replaces the hashed asset
+// files this tab was built against, so a lazy route import 404s. The fix is
+// to reload (the fresh index.html points at the new chunk names).
+function isStaleChunkError(err: unknown): boolean {
+  const msg = (err as Error)?.message ?? ""
+  return (
+    msg.includes("Failed to fetch dynamically imported module") ||
+    msg.includes("Importing a module script failed") ||
+    msg.includes("error loading dynamically imported module")
+  )
+}
+
+// Reload once to pick up the new build. The sessionStorage guard prevents an
+// infinite reload loop if the asset is genuinely missing (not just stale):
+// if we already reloaded in the last 10s and it still fails, give up and let
+// the real error surface instead of looping.
+const STALE_CHUNK_KEY = "stale-chunk-reload-ts"
+function recoverFromStaleChunk(): boolean {
+  const last = Number(sessionStorage.getItem(STALE_CHUNK_KEY) || 0)
+  if (Date.now() - last < 10_000) return false
+  sessionStorage.setItem(STALE_CHUNK_KEY, String(Date.now()))
+  window.location.reload()
+  return true
+}
+
+// Backstop for preload (modulepreload) failures that don't flow through lazy().
+window.addEventListener("vite:preloadError", (event) => {
+  if (recoverFromStaleChunk()) event.preventDefault()
+})
+
 function lazy(importFn: () => Promise<{ default: React.ComponentType }>) {
   return () =>
     importFn()
       .then((m) => ({ Component: m.default }))
       .catch((err) => {
-        if (
-          err.message?.includes("Failed to fetch dynamically imported module") ||
-          err.message?.includes("Importing a module script failed")
-        ) {
-          window.location.reload()
+        // If we can recover, return a never-resolving promise so React shows
+        // the route fallback (not the error screen) while the reload happens.
+        if (isStaleChunkError(err) && recoverFromStaleChunk()) {
+          return new Promise<never>(() => {})
         }
         throw err
       })


### PR DESCRIPTION
## Summary
After a deploy, an open tab still references the old content-hashed JS chunk filenames. Clicking a lazy-loaded route (e.g. a sidebar link) tries to fetch a chunk the new build removed → `Failed to fetch dynamically imported module` → the white "Unexpected Application Error" screen until a manual reload.

## Changes (`frontend/src/main.tsx`)
- On a stale-chunk error, reload **and** return a never-resolving promise so React shows the route fallback instead of flashing the error screen (the previous code reloaded but re-threw, causing the flash).
- `sessionStorage` guard prevents an infinite reload loop if an asset is genuinely missing (not just stale) — if it already reloaded within 10s and still fails, the real error surfaces.
- Listen for `vite:preloadError` as a backstop for `modulepreload` failures that don't flow through the lazy import path.

## Testing
- `tsc -b` passes (pre-push hook green).
- Behavioral note: only takes effect for tabs loaded from this build onward; the recovery is verifiable in production after deploy by opening a tab, shipping a new build, and navigating.