### PR TITLE
Quick-create tasks/events from search; case-detail tweaks

### DIFF
--- a/frontend/src/components/common/quick-case-search.tsx
+++ b/frontend/src/components/common/quick-case-search.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react"
 import { useNavigate } from "react-router"
 import { useQuery } from "@tanstack/react-query"
-import { useCasePreview } from "@/hooks/use-case-preview"
+import { useQuickCreate } from "@/hooks/use-quick-create"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   Search01Icon,
@@ -38,7 +38,7 @@ interface QuickCaseSearchProps {
 
 export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
   const navigate = useNavigate()
-  const { openCasePreview } = useCasePreview()
+  const { openQuickCreate } = useQuickCreate()
   const inputRef = useRef<HTMLInputElement>(null)
 
   const [query, setQuery] = useState("")
@@ -101,7 +101,8 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
     (item: SearchItem) => {
       onOpenChange(false)
       if (item.type === "case") {
-        openCasePreview(item.data.id)
+        // Quick search opens the full case detail page (not the preview modal).
+        navigate(`/cases/${item.data.id}`)
       } else {
         // Navigate to contacts page with the appropriate category
         if (item.data.type === "judge") {
@@ -111,7 +112,17 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
         }
       }
     },
-    [navigate, openCasePreview, onOpenChange]
+    [navigate, onOpenChange]
+  )
+
+  // ⌃/⌘+Enter on a case → new Event; ⇧+Enter → new Task (both for that case).
+  const handleQuickCreate = useCallback(
+    (item: SearchItem, kind: "task" | "event") => {
+      if (item.type !== "case") return
+      onOpenChange(false)
+      openQuickCreate(kind, item.data.id, item.data.case_name)
+    },
+    [openQuickCreate, onOpenChange]
   )
 
   const handleKeyDown = useCallback(
@@ -124,12 +135,18 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
         setSelectedIndex((i) => Math.max(i - 1, 0))
       } else if (e.key === "Enter") {
         e.preventDefault()
-        if (items[clampedIndex]) {
-          handleSelect(items[clampedIndex])
+        const item = items[clampedIndex]
+        if (!item) return
+        if (e.shiftKey) {
+          handleQuickCreate(item, "task")
+        } else if (e.ctrlKey || e.metaKey) {
+          handleQuickCreate(item, "event")
+        } else {
+          handleSelect(item)
         }
       }
     },
-    [items, clampedIndex, handleSelect]
+    [items, clampedIndex, handleSelect, handleQuickCreate]
   )
 
   function handleOpenChange(nextOpen: boolean) {
@@ -330,6 +347,10 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
           <kbd className="bg-muted px-1 py-0.5">↑↓</kbd> navigate
           {" · "}
           <kbd className="bg-muted px-1 py-0.5">Enter</kbd> open
+          {" · "}
+          <kbd className="bg-muted px-1 py-0.5">⌘/⌃Enter</kbd> new event
+          {" · "}
+          <kbd className="bg-muted px-1 py-0.5">⇧Enter</kbd> new task
           {" · "}
           <kbd className="bg-muted px-1 py-0.5">Esc</kbd> close
         </div>

--- a/frontend/src/components/common/quick-case-search.tsx
+++ b/frontend/src/components/common/quick-case-search.tsx
@@ -115,10 +115,12 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
     [navigate, onOpenChange]
   )
 
-  // ⌃/⌘+Enter on a case → new Event; ⇧+Enter → new Task (both for that case).
+  // ⌃T (Mac) / Alt+T → new Task; ⌃E / Alt+E → new Event, for the highlighted
+  // case. Uses Ctrl on Mac / Alt elsewhere to dodge reserved browser shortcuts
+  // (⌘T = new tab), matching the ⌃G search toggle.
   const handleQuickCreate = useCallback(
-    (item: SearchItem, kind: "task" | "event") => {
-      if (item.type !== "case") return
+    (item: SearchItem | undefined, kind: "task" | "event") => {
+      if (!item || item.type !== "case") return
       onOpenChange(false)
       openQuickCreate(kind, item.data.id, item.data.case_name)
     },
@@ -127,23 +129,23 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+      const createMod = isMac ? e.ctrlKey : e.altKey
+      const key = e.key.toLowerCase()
+
       if (e.key === "ArrowDown") {
         e.preventDefault()
         setSelectedIndex((i) => Math.min(i + 1, items.length - 1))
       } else if (e.key === "ArrowUp") {
         e.preventDefault()
         setSelectedIndex((i) => Math.max(i - 1, 0))
+      } else if (createMod && (key === "t" || key === "e")) {
+        e.preventDefault()
+        handleQuickCreate(items[clampedIndex], key === "t" ? "task" : "event")
       } else if (e.key === "Enter") {
         e.preventDefault()
         const item = items[clampedIndex]
-        if (!item) return
-        if (e.shiftKey) {
-          handleQuickCreate(item, "task")
-        } else if (e.ctrlKey || e.metaKey) {
-          handleQuickCreate(item, "event")
-        } else {
-          handleSelect(item)
-        }
+        if (item) handleSelect(item)
       }
     },
     [items, clampedIndex, handleSelect, handleQuickCreate]
@@ -348,9 +350,9 @@ export function QuickCaseSearch({ open, onOpenChange }: QuickCaseSearchProps) {
           {" · "}
           <kbd className="bg-muted px-1 py-0.5">Enter</kbd> open
           {" · "}
-          <kbd className="bg-muted px-1 py-0.5">⌘/⌃Enter</kbd> new event
+          <kbd className="bg-muted px-1 py-0.5">⌃T</kbd> new task
           {" · "}
-          <kbd className="bg-muted px-1 py-0.5">⇧Enter</kbd> new task
+          <kbd className="bg-muted px-1 py-0.5">⌃E</kbd> new event
           {" · "}
           <kbd className="bg-muted px-1 py-0.5">Esc</kbd> close
         </div>

--- a/frontend/src/components/common/quick-create-dialog.tsx
+++ b/frontend/src/components/common/quick-create-dialog.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Calendar03Icon,
+  CheckmarkCircle02Icon,
+  Loading03Icon,
+  Task01Icon,
+} from "@hugeicons/core-free-icons"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import { getStaff, type StaffMember } from "@/services/staff"
+import {
+  quickCreate,
+  type EventDraft,
+  type QuickCreateResponse,
+  type QuickKind,
+} from "@/services/quick-create"
+import { cn } from "@/lib/utils"
+
+interface QuickCreateDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  kind: QuickKind
+  caseId: number
+  caseName: string
+}
+
+/** Format a YYYY-MM-DD date-only string as "Fri, Jun 5" in Pacific time. */
+function formatDateOnly(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    timeZone: "America/Los_Angeles",
+  }).format(new Date(`${date}T00:00:00`))
+}
+
+function staffName(staff: StaffMember[], id: number | null | undefined): string | null {
+  if (id == null) return null
+  const s = staff.find((m) => m.id === id)
+  return s ? `${s.firstName} ${s.lastName}`.trim() : null
+}
+
+export function QuickCreateDialog({
+  open,
+  onOpenChange,
+  kind,
+  caseId,
+  caseName,
+}: QuickCreateDialogProps) {
+  const queryClient = useQueryClient()
+  const textRef = useRef<HTMLTextAreaElement>(null)
+
+  const [text, setText] = useState("")
+  const [phase, setPhase] = useState<"input" | "needs_date" | "done">("input")
+  const [draft, setDraft] = useState<EventDraft | null>(null)
+  const [dateInput, setDateInput] = useState("")
+  const [timeInput, setTimeInput] = useState("")
+  const [result, setResult] = useState<QuickCreateResponse | null>(null)
+
+  const { data: staffData } = useQuery({
+    queryKey: ["staff"],
+    queryFn: getStaff,
+    staleTime: 5 * 60 * 1000,
+  })
+  const staff = useMemo(() => staffData?.data ?? [], [staffData])
+
+  const noun = kind === "task" ? "task" : "event"
+
+  // Reset everything whenever the dialog (re)opens.
+  useEffect(() => {
+    if (open) {
+      setText("")
+      setPhase("input")
+      setDraft(null)
+      setDateInput("")
+      setTimeInput("")
+      setResult(null)
+      requestAnimationFrame(() => textRef.current?.focus())
+    }
+  }, [open, kind, caseId])
+
+  function handleSuccess(res: QuickCreateResponse) {
+    if (res.status === "needs_date") {
+      setDraft(res.draft)
+      setTimeInput(res.draft.time ?? "")
+      setPhase("needs_date")
+      return
+    }
+    setResult(res)
+    setPhase("done")
+    queryClient.invalidateQueries({ queryKey: ["tasks"] })
+    queryClient.invalidateQueries({ queryKey: ["events"] })
+    queryClient.invalidateQueries({ queryKey: ["case", caseId] })
+    toast.success(`Created ${noun}`)
+  }
+
+  const mutation = useMutation({
+    mutationFn: quickCreate,
+    onSuccess: handleSuccess,
+    onError: (e: Error) => toast.error(e.message || `Failed to create ${noun}`),
+  })
+
+  function submitText() {
+    const trimmed = text.trim()
+    if (!trimmed || mutation.isPending) return
+    mutation.mutate({ kind, case_id: caseId, text: trimmed })
+  }
+
+  function submitDate() {
+    if (!draft || !dateInput || mutation.isPending) return
+    mutation.mutate({
+      kind: "event",
+      case_id: caseId,
+      draft: { ...draft, date: dateInput, time: timeInput || null },
+    })
+  }
+
+  function handleTextKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      submitText()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-lg" showCloseButton={false}>
+        <DialogHeader className="border-b px-4 py-3">
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            <HugeiconsIcon
+              icon={kind === "task" ? Task01Icon : Calendar03Icon}
+              strokeWidth={2}
+              className="size-4"
+            />
+            New {kind === "task" ? "Task" : "Event"}
+          </DialogTitle>
+          <DialogDescription className="text-xs">{caseName}</DialogDescription>
+        </DialogHeader>
+
+        <div className="px-4 py-3">
+          {phase === "input" && (
+            <>
+              <Textarea
+                ref={textRef}
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onKeyDown={handleTextKeyDown}
+                disabled={mutation.isPending}
+                placeholder={
+                  kind === "task"
+                    ? "e.g. draft MSJ response, high priority, due Friday — assign to Dana"
+                    : "e.g. deposition of plaintiff next Tuesday at 10am at our office"
+                }
+                className="min-h-24 text-sm"
+              />
+              <div className="mt-3 flex items-center justify-between">
+                <span className="text-muted-foreground text-[10px]">
+                  <kbd className="bg-muted px-1 py-0.5">Enter</kbd> create ·{" "}
+                  <kbd className="bg-muted px-1 py-0.5">Shift+Enter</kbd> newline
+                </span>
+                <Button size="sm" onClick={submitText} disabled={!text.trim() || mutation.isPending}>
+                  {mutation.isPending ? (
+                    <HugeiconsIcon icon={Loading03Icon} className="size-4 animate-spin" />
+                  ) : (
+                    `Create ${kind === "task" ? "Task" : "Event"}`
+                  )}
+                </Button>
+              </div>
+            </>
+          )}
+
+          {phase === "needs_date" && draft && (
+            <div className="space-y-3">
+              <p className="text-sm">
+                When is <span className="font-medium">{draft.description}</span>?
+              </p>
+              <div className="flex items-end gap-2">
+                <div className="flex flex-col gap-1">
+                  <label className="text-muted-foreground text-[11px]">Date</label>
+                  <Input
+                    type="date"
+                    value={dateInput}
+                    onChange={(e) => setDateInput(e.target.value)}
+                    className="text-sm"
+                    autoFocus
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-muted-foreground text-[11px]">Time (optional)</label>
+                  <Input
+                    type="time"
+                    value={timeInput}
+                    onChange={(e) => setTimeInput(e.target.value)}
+                    className="text-sm"
+                  />
+                </div>
+                <Button size="sm" onClick={submitDate} disabled={!dateInput || mutation.isPending}>
+                  {mutation.isPending ? (
+                    <HugeiconsIcon icon={Loading03Icon} className="size-4 animate-spin" />
+                  ) : (
+                    "Create Event"
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {phase === "done" && result?.status === "created" && (
+            <SuccessView
+              result={result}
+              caseName={caseName}
+              staff={staff}
+              onAnother={() => {
+                setText("")
+                setPhase("input")
+                setResult(null)
+                setDraft(null)
+                requestAnimationFrame(() => textRef.current?.focus())
+              }}
+              onClose={() => onOpenChange(false)}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SuccessView({
+  result,
+  caseName,
+  staff,
+  onAnother,
+  onClose,
+}: {
+  result: Extract<QuickCreateResponse, { status: "created" }>
+  caseName: string
+  staff: StaffMember[]
+  onAnother: () => void
+  onClose: () => void
+}) {
+  let title = ""
+  const meta: string[] = [caseName]
+
+  if (result.kind === "task") {
+    const t = result.task
+    title = t.description
+    meta.push(t.urgency)
+    meta.push(t.due_date ? `due ${formatDateOnly(t.due_date)}` : "no due date")
+    const who = staffName(staff, t.assignee_id)
+    if (who) meta.push(who)
+  } else {
+    const ev = result.event
+    title = ev.description
+    meta.push(formatDateOnly(ev.date))
+    if (ev.time) meta.push(ev.time.slice(0, 5))
+    if (ev.location) meta.push(ev.location)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-2">
+        <HugeiconsIcon
+          icon={CheckmarkCircle02Icon}
+          strokeWidth={2}
+          className={cn("mt-0.5 size-5 shrink-0", "text-success")}
+        />
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium">{title}</span>
+          <span className="text-muted-foreground text-xs">{meta.join(" · ")}</span>
+        </div>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Button size="sm" variant="outline" onClick={onAnother}>
+          Create another
+        </Button>
+        <Button size="sm" onClick={onClose}>
+          Done
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/root-layout.tsx
+++ b/frontend/src/components/layout/root-layout.tsx
@@ -11,6 +11,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { QuickCaseSearch } from "@/components/common/quick-case-search"
 import { AiChatSheet, type ToolCompletionRule } from "@/components/common/ai-chat-sheet"
 import { CasePreviewProvider } from "@/hooks/use-case-preview"
+import { QuickCreateProvider } from "@/hooks/use-quick-create"
 import { Button } from "@/components/ui/button"
 
 /** Extract case ID from the current URL path if on a case detail page. */
@@ -76,6 +77,7 @@ export function RootLayout() {
   return (
     <TooltipProvider>
       <CasePreviewProvider>
+      <QuickCreateProvider>
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset>
@@ -108,6 +110,7 @@ export function RootLayout() {
         caseContext={caseContext}
         toolCompletionRules={chatRules}
       />
+      </QuickCreateProvider>
       </CasePreviewProvider>
     </TooltipProvider>
   )

--- a/frontend/src/hooks/use-quick-create.tsx
+++ b/frontend/src/hooks/use-quick-create.tsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react"
+import { QuickCreateDialog } from "@/components/common/quick-create-dialog"
+import type { QuickKind } from "@/services/quick-create"
+
+type QuickCreateConfig = { kind: QuickKind; caseId: number; caseName: string }
+
+type QuickCreateContextValue = {
+  /**
+   * Open the AI quick-create dialog for a known case. `kind` chooses task vs
+   * event; the case is the one highlighted in quick search (so no @-mentions).
+   */
+  openQuickCreate: (kind: QuickKind, caseId: number, caseName: string) => void
+}
+
+const QuickCreateContext = createContext<QuickCreateContextValue | null>(null)
+
+/**
+ * App-level provider that renders a single QuickCreateDialog and lets any
+ * component open it via `useQuickCreate().openQuickCreate(...)`.
+ */
+export function QuickCreateProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  // Retained while closing so the dialog can animate out before unmounting.
+  const [config, setConfig] = useState<QuickCreateConfig | null>(null)
+
+  const openQuickCreate = useCallback(
+    (kind: QuickKind, caseId: number, caseName: string) => {
+      setConfig({ kind, caseId, caseName })
+      setOpen(true)
+    },
+    []
+  )
+
+  const value = useMemo(() => ({ openQuickCreate }), [openQuickCreate])
+
+  return (
+    <QuickCreateContext.Provider value={value}>
+      {children}
+      {config && (
+        <QuickCreateDialog
+          open={open}
+          onOpenChange={setOpen}
+          kind={config.kind}
+          caseId={config.caseId}
+          caseName={config.caseName}
+        />
+      )}
+    </QuickCreateContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useQuickCreate() {
+  const context = useContext(QuickCreateContext)
+  if (!context) {
+    throw new Error("useQuickCreate must be used within a QuickCreateProvider")
+  }
+  return context
+}

--- a/frontend/src/pages/cases/detail.tsx
+++ b/frontend/src/pages/cases/detail.tsx
@@ -24,7 +24,8 @@ import { AiChatSheet, type ToolCompletionRule } from "@/components/common/ai-cha
 import { FeatureGate } from "@/components/common/feature-gate"
 import { CaseDetailHeader } from "@/pages/cases/components/case-detail-header"
 import { CaseSummarySection } from "@/pages/cases/components/case-summary-section"
-import { CaseRepresentationCard } from "@/pages/cases/components/case-representation-card"
+// Hidden until finished — see GH #148
+// import { CaseRepresentationCard } from "@/pages/cases/components/case-representation-card"
 import { CaseActivityFeed } from "@/pages/cases/components/case-activity-feed"
 import { CaseInfoPanel } from "@/pages/cases/components/case-info-panel"
 import { CaseWorkLog } from "@/pages/cases/components/case-work-log"
@@ -245,7 +246,8 @@ function CaseDetailContent() {
               onAiPeople={() => setAiPeopleOpen(true)}
               onNest={handleNest}
             />
-            <CaseRepresentationCard caseData={caseData} />
+            {/* Representation section hidden until finished — see GH #148 */}
+            {/* <CaseRepresentationCard caseData={caseData} /> */}
             {showTasks && (
               <CaseTasksCard
                 caseId={caseData.id}
@@ -265,6 +267,7 @@ function CaseDetailContent() {
             {showFinancials && (
               <CaseFinancialsCard caseId={caseData.id} casePersons={caseData.persons} />
             )}
+            <CaseWorkLog caseId={caseData.id} />
 
             {user?.isAdmin && (
               <div className="flex justify-end pt-4 border-t border-border/40">
@@ -303,7 +306,6 @@ function CaseDetailContent() {
               <CaseHealthCard caseId={caseData.id} />
               <CaseKeyDates caseData={caseData} />
               <CaseInfoPanel caseData={caseData} />
-              <CaseWorkLog caseId={caseData.id} />
               <CaseActivityFeed caseId={caseData.id} />
             </div>
           </div>

--- a/frontend/src/services/quick-create.ts
+++ b/frontend/src/services/quick-create.ts
@@ -1,0 +1,65 @@
+import { apiFetch } from "@/lib/api"
+
+export type QuickKind = "task" | "event"
+
+/** The event fields the AI extracted; reused verbatim when finalizing a date. */
+export interface EventDraft {
+  description: string
+  date: string | null
+  time: string | null
+  location: string | null
+  notes: string | null
+  event_type: string | null
+  attendee_ids: number[]
+}
+
+export interface CreatedTask {
+  id: number
+  description: string
+  due_date: string | null
+  urgency: string
+  assignee_id: number | null
+}
+
+export interface CreatedEvent {
+  id: number
+  description: string
+  date: string
+  time: string | null
+  location: string | null
+}
+
+export type QuickCreateResponse =
+  | { status: "created"; kind: "task"; task: CreatedTask }
+  | { status: "created"; kind: "event"; event: CreatedEvent }
+  | { status: "needs_date"; draft: EventDraft }
+
+export interface QuickCreatePayload {
+  kind: QuickKind
+  case_id: number
+  /** Natural-language note (omit when finalizing an event draft). */
+  text?: string
+  /** A prior event draft with the date filled in (event finalize path). */
+  draft?: EventDraft
+}
+
+export async function quickCreate(
+  payload: QuickCreatePayload
+): Promise<QuickCreateResponse> {
+  const res = await apiFetch("/api/v1/quick-create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    let msg = "Failed to create"
+    try {
+      const body = await res.json()
+      msg = body?.error?.message || body?.message || msg
+    } catch {
+      // ignore
+    }
+    throw new Error(msg)
+  }
+  return res.json()
+}

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -77,6 +77,7 @@ from .checklist import register_checklist_routes
 from .trial_calendar import register_trial_calendar_routes
 from .dale import register_dale_routes
 from .alerts import register_alert_routes
+from .quickcreate import register_quickcreate_routes
 from .static import register_static_routes
 
 # Re-export common utilities
@@ -164,6 +165,8 @@ def register_routes(mcp):
     register_dale_routes(mcp)
     _logger.debug("Registering alert routes...")
     register_alert_routes(mcp)
+    _logger.debug("Registering quick-create routes...")
+    register_quickcreate_routes(mcp)
 
     # Register static/SPA routes last (catch-all must be last)
     _logger.debug("Registering static routes...")
@@ -200,5 +203,6 @@ __all__ = [
     "register_lien_routes",
     "register_activity_routes",
     "register_worklog_routes",
+    "register_quickcreate_routes",
     "register_static_routes",
 ]

--- a/routes/quickcreate.py
+++ b/routes/quickcreate.py
@@ -1,0 +1,148 @@
+"""
+Quick-create routes.
+
+A single endpoint behind the quick-search bar's ⌃Enter / ⇧Enter shortcuts:
+turn a short natural-language note into ONE task or event for the highlighted
+case via a one-shot AI parse, then create it with the same side effects
+(system comments + SSE broadcast) as the regular create routes.
+
+Flow:
+- POST {kind, case_id, text}        -> AI parse -> create (task), or
+                                        create (event) when a date is found.
+- An event with no resolvable date  -> {"status": "needs_date", "draft": {...}}.
+- POST {kind:"event", case_id, draft}-> finalize the draft (date filled in by the
+                                        user) and create — no AI call.
+"""
+
+import asyncio
+
+from fastapi.responses import JSONResponse
+
+import db
+import auth
+from db.comments import add_comment as add_entity_comment
+from db.validation import ValidationError as DbValidationError
+from .common import api_error, feature_disabled_error
+from .comments import _get_db_user_id
+from .sse import broadcast
+
+
+def register_quickcreate_routes(mcp):
+    """Register quick-create routes."""
+
+    @mcp.custom_route("/api/v1/quick-create", methods=["POST"])
+    async def api_quick_create(request):
+        if err := auth.require_auth(request):
+            return err
+
+        body = await request.json()
+        kind = body.get("kind")
+        case_id = body.get("case_id")
+        text = (body.get("text") or "").strip()
+        draft = body.get("draft")
+
+        if kind not in ("task", "event"):
+            return api_error("kind must be 'task' or 'event'", "BAD_REQUEST", 400)
+        if not case_id:
+            return api_error("case_id is required", "BAD_REQUEST", 400)
+
+        user = auth.get_current_user(request)
+        user_id = _get_db_user_id(user)
+
+        # Event finalize path: the draft was produced by a prior parse and the
+        # user has now supplied the date — create directly, skip the AI.
+        if kind == "event" and isinstance(draft, dict):
+            parsed = draft
+        else:
+            if not text:
+                return api_error("text is required", "BAD_REQUEST", 400)
+            from services.quick_create import parse_quick_item
+            try:
+                parsed = await asyncio.to_thread(parse_quick_item, kind, text)
+            except Exception as e:  # AI/config failure — surface cleanly
+                return api_error(f"Could not parse note: {e}", "PARSE_FAILED", 502)
+
+        try:
+            if kind == "task":
+                return await _create_task(int(case_id), parsed, user, user_id)
+            # event: needs a date before we can create one
+            if not parsed.get("date"):
+                return JSONResponse({"status": "needs_date", "draft": parsed})
+            return await _create_event(int(case_id), parsed, user, user_id)
+        except db.FeatureDisabled as e:
+            return feature_disabled_error(e)
+        except (DbValidationError, ValueError) as e:
+            return api_error(str(e), "VALIDATION_ERROR", 400)
+
+
+async def _create_task(case_id, parsed, user, user_id):
+    result = await asyncio.to_thread(
+        db.add_task,
+        case_id,
+        parsed["description"],
+        parsed.get("due_date"),
+        "Pending",
+        parsed.get("urgency") or "Medium",
+        None,  # event_id
+        parsed.get("assignee_id"),
+        None,  # completion_date
+        None,  # intake_id
+    )
+    task_id = result.get("id")
+
+    # Mirror routes/tasks.py side effects so the list/activity update live.
+    if user:
+        name = f"{user['firstName']} {user['lastName']}"
+        desc = parsed["description"][:80] + ("..." if len(parsed["description"]) > 80 else "")
+        if task_id:
+            await asyncio.to_thread(
+                add_entity_comment, "task", task_id, user_id,
+                f"{name} created this task", True,
+            )
+            broadcast({
+                "entity": "comment", "action": "created", "id": None,
+                "entity_type": "task", "entity_id": task_id, "user_id": user_id,
+            })
+        await asyncio.to_thread(
+            db.add_case_comment, case_id, user_id, f'{name} added task: "{desc}"', True,
+        )
+
+    broadcast({"entity": "task", "action": "created", "id": task_id, "case_id": case_id})
+    return JSONResponse({"status": "created", "kind": "task", "task": result})
+
+
+async def _create_event(case_id, parsed, user, user_id):
+    result = await asyncio.to_thread(
+        db.add_event,
+        case_id,
+        parsed["date"],
+        parsed["description"],
+        None,  # document_link
+        None,  # calculation_note
+        parsed.get("time"),
+        parsed.get("location"),
+        False,  # starred
+        parsed.get("event_type"),
+        None,  # end_date
+        False,  # blocks_calendar — case-scoped AI never blocks the calendar
+        notes=parsed.get("notes"),
+        on_trial_calendar=False,
+    )
+    event_id = result.get("id")
+
+    # Attendees are a separate relation; add each matched staff member.
+    for uid in (parsed.get("attendee_ids") or []):
+        try:
+            await asyncio.to_thread(db.add_event_attendee, event_id, int(uid))
+        except Exception:
+            pass  # a bad id shouldn't sink the whole event
+
+    if user and case_id:
+        name = f"{user['firstName']} {user['lastName']}"
+        desc = parsed["description"][:80] + ("..." if len(parsed["description"]) > 80 else "")
+        await asyncio.to_thread(
+            db.add_case_comment, case_id, user_id, f'{name} added event: "{desc}"', True,
+        )
+
+    broadcast({"entity": "event", "action": "created", "id": event_id, "case_id": case_id})
+    return JSONResponse({"status": "created", "kind": "event", "event": result})

--- a/services/quick_create.py
+++ b/services/quick_create.py
@@ -1,0 +1,268 @@
+"""
+Quick-create service.
+
+A single, synchronous Claude call (forced tool use) that turns a short
+natural-language note into ONE task or event for a *known* case. The case is
+already chosen by the caller (the highlighted quick-search result), so unlike
+the worklog consolidator there is no case matching — only field extraction.
+
+Deliberate product rules (do NOT relax these):
+- Never ask follow-up questions.
+- A task with no date  -> due_date = null (just create it).
+- An event with no date -> the route returns ``needs_date`` and asks ONLY for
+  the date; this service simply leaves ``date`` null when it can't resolve one.
+- Relative dates ("next Tuesday", "in 3 days") are resolved against TODAY,
+  which is passed in (Pacific calendar date).
+
+Mirrors services/worklog_consolidator.py for the forced-tool LLM pattern.
+"""
+
+import json
+import logging
+import os
+import re
+from datetime import date, timedelta
+
+from anthropic import Anthropic
+
+from db.token_usage import record_usage_from_message
+from db.users import get_all_users
+from lib.tz import today_la
+
+logger = logging.getLogger(__name__)
+
+URGENCY_VALUES = ["Low", "Medium", "High", "Urgent"]
+EVENT_TYPE_HINT = (
+    "trial, oral_argument, hearing, mediation, deposition, conference, "
+    "vacation, holiday, other"
+)
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TIME_RE = re.compile(r"^\d{2}:\d{2}$")
+
+TASK_TOOL = {
+    "name": "submit_task",
+    "description": "Create a single task from the user's note.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "description": {
+                "type": "string",
+                "description": (
+                    "Concise task title in imperative form (e.g. 'Draft MSJ "
+                    "response'). Do NOT include the case name — the case is "
+                    "recorded separately."
+                ),
+            },
+            "due_date": {
+                "type": ["string", "null"],
+                "description": (
+                    "Due date as YYYY-MM-DD, resolved against TODAY. Null if the "
+                    "note gives no date — never invent one."
+                ),
+            },
+            "urgency": {
+                "type": "string",
+                "enum": URGENCY_VALUES,
+                "description": "Urgency inferred from the note's tone. Default 'Medium'.",
+            },
+            "assignee_id": {
+                "type": ["integer", "null"],
+                "description": (
+                    "Id of the single staff member to assign, matched by name "
+                    "against CANDIDATE STAFF. Null if no one is named."
+                ),
+            },
+        },
+        "required": ["description"],
+    },
+}
+
+EVENT_TOOL = {
+    "name": "submit_event",
+    "description": "Create a single calendar event from the user's note.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "description": {
+                "type": "string",
+                "description": (
+                    "Concise event title (e.g. 'Deposition of plaintiff'). Do "
+                    "NOT include the case name."
+                ),
+            },
+            "date": {
+                "type": ["string", "null"],
+                "description": (
+                    "Event date as YYYY-MM-DD, resolved against TODAY. Null if "
+                    "the note gives no resolvable date — never invent one."
+                ),
+            },
+            "time": {
+                "type": ["string", "null"],
+                "description": "Start time in 24-hour HH:MM (e.g. '10:00', '14:30'). Null if none.",
+            },
+            "location": {
+                "type": ["string", "null"],
+                "description": "Location if mentioned, else null.",
+            },
+            "notes": {
+                "type": ["string", "null"],
+                "description": "Any extra detail worth recording, else null.",
+            },
+            "event_type": {
+                "type": ["string", "null"],
+                "description": f"One of: {EVENT_TYPE_HINT}. Null if unclear.",
+            },
+            "attendee_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": (
+                    "Ids of staff attending, matched by name against CANDIDATE "
+                    "STAFF. Empty if no one is named."
+                ),
+            },
+        },
+        "required": ["description"],
+    },
+}
+
+_TASK_SYSTEM = (
+    "You convert a short note into ONE task for a case the user already chose. "
+    "Call submit_task exactly once. Never ask questions and never add commentary.\n"
+    "- Write a concise imperative title; omit the case name.\n"
+    "- Set due_date ONLY if the note implies one, resolving relative dates via "
+    "the DATE REFERENCE table (never compute dates yourself); otherwise null.\n"
+    "- Infer urgency from tone (default Medium).\n"
+    "- Set assignee_id only when a CANDIDATE STAFF member is clearly named."
+)
+
+_EVENT_SYSTEM = (
+    "You convert a short note into ONE calendar event for a case the user "
+    "already chose. Call submit_event exactly once. Never ask questions and "
+    "never add commentary.\n"
+    "- Write a concise event title; omit the case name.\n"
+    "- Resolve the date via the DATE REFERENCE table (never compute dates "
+    "yourself). If the note gives no resolvable date, set date to null (the app "
+    "will ask the user separately) — never guess.\n"
+    "- Use 24-hour HH:MM for time.\n"
+    "- Set attendee_ids only for CANDIDATE STAFF members clearly named."
+)
+
+
+def _staff_candidates() -> list[dict]:
+    """Active attorneys/paralegals as {id, name} for assignment matching."""
+    users = get_all_users(include_inactive=False)
+    out = []
+    for u in users:
+        if u.get("position") not in ("attorney", "paralegal"):
+            continue
+        name = f"{u.get('first_name') or ''} {u.get('last_name') or ''}".strip()
+        out.append({"id": u["id"], "name": name})
+    return out
+
+
+def _client_and_model():
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY environment variable is required")
+    from config import settings
+    return Anthropic(api_key=api_key), settings.chat_model_full
+
+
+def _date_reference(today: date, days: int = 21) -> str:
+    """A precomputed calendar so the model never does its own date math.
+
+    LLMs are unreliable at "what date is next Friday?". Python computes the
+    weekday for each of the next `days` days; the model just looks the phrase up.
+    """
+    lines = []
+    for i in range(days):
+        d = today + timedelta(days=i)
+        suffix = " (today)" if i == 0 else " (tomorrow)" if i == 1 else ""
+        lines.append(f"{d.isoformat()} = {d.strftime('%A')}{suffix}")
+    return "\n".join(lines)
+
+
+def parse_quick_item(kind: str, text: str) -> dict:
+    """Parse ``text`` into a single task/event dict for a known case.
+
+    Returns the validated field dict (ids checked against real staff, dates and
+    times normalised — anything malformed is dropped to null rather than raised).
+    """
+    if kind not in ("task", "event"):
+        raise ValueError(f"Unknown quick-create kind: {kind}")
+
+    staff = _staff_candidates()
+    today = today_la()
+    client, model = _client_and_model()
+
+    tool = TASK_TOOL if kind == "task" else EVENT_TOOL
+    system = _TASK_SYSTEM if kind == "task" else _EVENT_SYSTEM
+    content = (
+        f"TODAY: {today.isoformat()} ({today.strftime('%A')})\n\n"
+        f"DATE REFERENCE — resolve every date by LOOKING IT UP here; never do "
+        f"your own calendar arithmetic. Conventions: a bare or 'this <weekday>' "
+        f"= the nearest such day after today; 'next <weekday>' = that day in the "
+        f"following week; 'the <weekday> after next' = a further 7 days again:\n"
+        f"{_date_reference(today)}\n\n"
+        f"NOTE:\n{text.strip()}\n\n"
+        f"CANDIDATE STAFF (match names; use the id):\n"
+        f"{json.dumps(staff, ensure_ascii=False)}"
+    )
+
+    message = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=system,
+        tools=[tool],
+        tool_choice={"type": "tool", "name": tool["name"]},
+        messages=[{"role": "user", "content": content}],
+    )
+    record_usage_from_message(
+        source="quick_create", request_type=kind, model=model, message=message,
+    )
+
+    raw = None
+    for block in message.content:
+        if block.type == "tool_use" and block.name == tool["name"]:
+            raw = block.input
+            break
+    if raw is None:
+        raise ValueError("Quick-create failed - no tool call received")
+
+    valid_staff_ids = {s["id"] for s in staff}
+    description = (raw.get("description") or "").strip()
+    if not description:
+        raise ValueError("Quick-create produced an empty description")
+
+    def _date(v):
+        return v if isinstance(v, str) and _DATE_RE.match(v) else None
+
+    def _time(v):
+        return v if isinstance(v, str) and _TIME_RE.match(v) else None
+
+    if kind == "task":
+        urgency = raw.get("urgency")
+        if urgency not in URGENCY_VALUES:
+            urgency = "Medium"
+        assignee_id = raw.get("assignee_id")
+        if assignee_id not in valid_staff_ids:
+            assignee_id = None
+        return {
+            "description": description,
+            "due_date": _date(raw.get("due_date")),
+            "urgency": urgency,
+            "assignee_id": assignee_id,
+        }
+
+    attendee_ids = [i for i in (raw.get("attendee_ids") or []) if i in valid_staff_ids]
+    return {
+        "description": description,
+        "date": _date(raw.get("date")),
+        "time": _time(raw.get("time")),
+        "location": (raw.get("location") or None),
+        "notes": (raw.get("notes") or None),
+        "event_type": (raw.get("event_type") or None),
+        "attendee_ids": attendee_ids,
+    }


### PR DESCRIPTION
## Summary

Adds AI-powered quick-create of tasks and events straight from the quick-search bar, plus two case-detail page tweaks.

### Quick-create (⌃G search bar)
- **⌃T** → new task, **⌃E** → new event for the highlighted case (Alt+T/Alt+E on Windows/Linux to avoid reserved browser shortcuts). **Enter** now opens the full case detail page.
- Opens a popup dialog: type a natural-language note → one-shot Claude call (forced tool use) fills name, date, urgency, and assignees → creates it and confirms. **No follow-up questions**, except an event with no date, which prompts only for the date.
- Dates resolved via a Python-computed date-reference table injected into the prompt, so weekday math is exact.

New: `services/quick_create.py`, `routes/quickcreate.py` (`POST /api/v1/quick-create`), `frontend` dialog + provider + service. No new MCP tools; no Dockerfile change (dir-copied).

### Case detail page
- **Representation section hidden** until finished — tracked in #148 (one-line re-enable).
- **Worklog moved** from the right column (above the activity log) to the left column, directly below financials.

## Testing
- Backend create paths verified end-to-end against a real case (task, event-with-date, event needs_date, draft finalize); date phrasings checked; test rows + comments cleaned up.
- Frontend type-checks clean; servers run.

Closes nothing automatically; relates to #148.