### PR TITLE
fix: contact detail modal scrolls long notes (missed by #149)

### DIFF
--- a/frontend/src/components/common/contact-detail-dialog.tsx
+++ b/frontend/src/components/common/contact-detail-dialog.tsx
@@ -372,7 +372,7 @@ export function ContactDetailDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-lg">
         {showActionsMenu && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -472,7 +472,7 @@ export function ContactDetailDialog({
           </div>
         </DialogHeader>
 
-        <div className="space-y-4 mt-2">
+        <div className="-mr-2 mt-2 min-h-0 flex-1 space-y-4 overflow-y-auto pr-2">
           {/* Organization */}
           <div className="space-y-1">
             <div className="flex items-center gap-1.5">

--- a/frontend/src/components/common/inline-edit-field.tsx
+++ b/frontend/src/components/common/inline-edit-field.tsx
@@ -125,7 +125,9 @@ function InlineEditFieldInner({
         displayClassName
       )}
     >
-      <span className="break-words">{value || placeholder}</span>
+      <span className={cn("break-words", type === "textarea" && "whitespace-pre-wrap")}>
+        {value || placeholder}
+      </span>
       <HugeiconsIcon
         icon={PencilEdit01Icon}
         className="size-3 shrink-0 opacity-0 group-hover/edit:opacity-50 transition-opacity"


### PR DESCRIPTION
## Why

PR #149 was merged before this commit landed on `staging`, so the contact/person detail modal scroll fix never reached `main` — the deployed site still shows long notes overflowing the modal off-screen.

## What

`d074dcf` — `ContactDetailDialog` is capped at 85vh as a flex column with the body as the scroll region (`min-h-0` + `overflow-y-auto`); textarea-type inline fields (notes, summaries) render with `whitespace-pre-wrap` so line breaks are preserved.

Verified by measurement on local dev: the dialog stays within the viewport and the body scrolls internally even with very long content.

## After merge

Deploys from `main` → fixes the modal on galipo.coopermayne.com.