### PR TITLE
feat(quick-search): exclude Done tasks from task search

### DIFF
--- a/db/tasks.py
+++ b/db/tasks.py
@@ -389,7 +389,7 @@ def reschedule_overdue_tasks(new_date: str, task_ids: List[int] = None) -> dict:
 def search_tasks(query: str = None, case_id: int = None, status: str = None,
                  urgency: str = None, assignee_id: int = None, limit: int = 50,
                  user_id: int = None, due_date_before: str = None,
-                 due_date_after: str = None) -> List[dict]:
+                 due_date_after: str = None, exclude_status: str = None) -> List[dict]:
     """Search tasks by various criteria."""
     if status:
         validate_task_status(status)
@@ -427,6 +427,8 @@ def search_tasks(query: str = None, case_id: int = None, status: str = None,
         stmt = stmt.where(Task.case_id == case_id)
     if status:
         stmt = stmt.where(Task.status == status)
+    if exclude_status:
+        stmt = stmt.where(Task.status != exclude_status)
     if urgency:
         stmt = stmt.where(Task.urgency == urgency)
     if assignee_id:

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -123,6 +123,7 @@ def register_task_routes(mcp):
         user_id = user["id"] if (my_tasks and user) else None
         results = await asyncio.to_thread(
             db.search_tasks, query=q, user_id=user_id, limit=limit,
+            exclude_status="Done",
         )
         return JSONResponse({"tasks": results, "total": len(results)})
 


### PR DESCRIPTION
## Summary

Completed (`Done`) tasks were cluttering the quick-search Tasks section. They're now excluded from task search results.

## Change

- `db.search_tasks` gains an optional `exclude_status` param (MCP callers unaffected — defaults to None).
- `GET /api/v1/tasks/search` passes `exclude_status="Done"`.

Filtered in the DB query (not post-hoc) so the result count and `limit` stay accurate. Side effect: marking a task **Done** from the search results now drops it on the next refresh.

## Verified

Local: a query that previously surfaced two `Done` tasks now returns zero. Backend imports clean.