### PR TITLE
feat(court-listener): slim down the table width

### DIFF
--- a/db/webhooks.py
+++ b/db/webhooks.py
@@ -31,18 +31,20 @@ def _attach_case_context(session, dicts: List[dict]) -> List[dict]:
         return dicts
 
     rows = session.execute(
-        select(Proceeding.id, Proceeding.case_number, Case.id, Case.case_name)
+        select(Proceeding.id, Proceeding.case_number, Case.id, Case.case_name, Case.short_name)
         .join(Case, Case.id == Proceeding.case_id, isouter=True)
         .where(Proceeding.id.in_(proc_ids))
     ).all()
     by_proc = {
-        r[0]: {"case_number": r[1], "case_id": r[2], "case_name": r[3]} for r in rows
+        r[0]: {"case_number": r[1], "case_id": r[2], "case_name": r[3], "case_short_name": r[4]}
+        for r in rows
     }
     for d in dicts:
         ctx = by_proc.get(d.get("proceeding_id"))
         if ctx:
             d["case_id"] = ctx["case_id"]
             d["case_name"] = ctx["case_name"]
+            d["case_short_name"] = ctx["case_short_name"]
             d["case_number"] = ctx["case_number"]
     return dicts
 

--- a/frontend/src/pages/court-listener/columns.tsx
+++ b/frontend/src/pages/court-listener/columns.tsx
@@ -10,8 +10,6 @@ import {
   Unlink01Icon,
 } from "@hugeicons/core-free-icons"
 import { DataTableColumnHeader } from "@/components/common/data-table-column-header"
-import { formatTimestamp } from "@/lib/datetime"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -19,7 +17,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { cn } from "@/lib/utils"
 
 const CL_STORAGE_BASE = "https://storage.courtlistener.com"
 const CL_BASE = "https://www.courtlistener.com"
@@ -100,13 +97,6 @@ function slugToCaseName(slug: string): string {
     .replace(/ And /g, " and ")
 }
 
-const statusStyles: Record<string, string> = {
-  pending: "bg-warning text-warning-foreground",
-  processing: "bg-info text-info-foreground",
-  completed: "bg-success text-success-foreground",
-  failed: "bg-destructive text-destructive-foreground",
-}
-
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "—"
   const d = new Date(dateStr + "T00:00:00")
@@ -115,10 +105,6 @@ function formatDate(dateStr: string | null): string {
     day: "numeric",
     year: "numeric",
   })
-}
-
-function formatDateTime(dateStr: string | null): string {
-  return formatTimestamp(dateStr)
 }
 
 interface ColumnOptions {
@@ -139,53 +125,30 @@ export function getColumns({
   return [
     {
       id: "linked_case",
-      accessorFn: (row) => row.case_name ?? "",
+      accessorFn: (row) => row.case_short_name ?? row.case_name ?? "",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Case" />
       ),
       cell: ({ row }) => {
         const wh = row.original
-        if (!wh.case_id || !wh.case_name) {
-          return <span className="text-muted-foreground">—</span>
+        // No proceeding/case linked → show "unlinked" right here.
+        if (!wh.case_id) {
+          return <span className="text-muted-foreground italic">unlinked</span>
         }
         const caseId = wh.case_id
+        const label = wh.case_short_name || wh.case_name || wh.case_number || "Case"
         return (
           <button
             type="button"
             onClick={() => onOpenCase(caseId)}
-            className="font-medium hover:underline cursor-pointer text-left"
-            title={wh.case_number ?? undefined}
+            className="font-medium hover:underline cursor-pointer text-left whitespace-nowrap"
+            title={wh.case_name ?? wh.case_number ?? undefined}
           >
-            {wh.case_name}
+            {label}
           </button>
         )
       },
       filterFn: "includesString",
-    },
-    {
-      id: "link_status",
-      accessorFn: (row) => (row.proceeding_id ? "Linked" : "Unlinked"),
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Link" />
-      ),
-      cell: ({ row }) => {
-        const linked = !!row.original.proceeding_id
-        return (
-          <Badge
-            className={cn(
-              "border-0 font-medium",
-              linked
-                ? "bg-success text-success-foreground"
-                : "bg-muted text-muted-foreground"
-            )}
-          >
-            {linked ? "Linked" : "Unlinked"}
-          </Badge>
-        )
-      },
-      filterFn: (row, id, value: string[]) => {
-        return value.includes(row.getValue(id) as string)
-      },
     },
     {
       id: "case_name",
@@ -228,9 +191,11 @@ export function getColumns({
       cell: ({ row }) => {
         const entry = extractEntry(row.original)
         if (!entry?.description) return <span className="text-muted-foreground">—</span>
+        const desc = entry.description
+        const short = desc.length > 20 ? `${desc.slice(0, 20)}…` : desc
         return (
-          <span className="text-xs line-clamp-2 max-w-md" title={entry.description}>
-            {entry.description}
+          <span className="text-xs whitespace-nowrap" title={desc}>
+            {short}
           </span>
         )
       },
@@ -300,34 +265,6 @@ export function getColumns({
           </DropdownMenu>
         )
       },
-    },
-    {
-      accessorKey: "processing_status",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Status" />
-      ),
-      cell: ({ row }) => {
-        const status = row.original.processing_status
-        return (
-          <Badge className={cn("border-0 font-medium", statusStyles[status] ?? "bg-muted text-muted-foreground")}>
-            {status}
-          </Badge>
-        )
-      },
-      filterFn: (row, id, value: string[]) => {
-        return value.includes(row.getValue(id) as string)
-      },
-    },
-    {
-      accessorKey: "created_at",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Received" />
-      ),
-      cell: ({ row }) => (
-        <span className="text-xs whitespace-nowrap">
-          {formatDateTime(row.original.created_at)}
-        </span>
-      ),
     },
     {
       id: "actions",

--- a/frontend/src/pages/court-listener/index.tsx
+++ b/frontend/src/pages/court-listener/index.tsx
@@ -38,26 +38,13 @@ import {
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataTablePagination } from "@/components/common/data-table-pagination"
-import { DataTableFacetedFilter } from "@/components/common/data-table-faceted-filter"
 import { DataTableViewOptions } from "@/components/common/data-table-view-options"
-
-const statusFilterOptions = [
-  { label: "Pending", value: "pending" },
-  { label: "Processing", value: "processing" },
-  { label: "Completed", value: "completed" },
-  { label: "Failed", value: "failed" },
-]
-
-const linkFilterOptions = [
-  { label: "Linked", value: "Linked" },
-  { label: "Unlinked", value: "Unlinked" },
-]
 
 export default function CourtListenerPage() {
   const queryClient = useQueryClient()
   const { openCasePreview } = useCasePreview()
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "created_at", desc: true },
+    { id: "date_filed", desc: true },
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
@@ -184,16 +171,6 @@ export default function CourtListenerPage() {
             className="h-8 pl-8"
           />
         </div>
-        <DataTableFacetedFilter
-          column={table.getColumn("link_status")}
-          title="Link"
-          options={linkFilterOptions}
-        />
-        <DataTableFacetedFilter
-          column={table.getColumn("processing_status")}
-          title="Status"
-          options={statusFilterOptions}
-        />
         <DataTableViewOptions table={table} />
       </div>
 

--- a/frontend/src/types/webhook.ts
+++ b/frontend/src/types/webhook.ts
@@ -15,6 +15,7 @@ export interface WebhookLog {
   // Linked case context (derived from proceeding -> case)
   case_id: number | null
   case_name: string | null
+  case_short_name: string | null
   case_number: string | null
 }
 


### PR DESCRIPTION
## Summary

The /court-listener table was too wide even on a wide screen. This trims it down.

## Changes
- **Case column**: shows the **case short name** (added `case_short_name` to the webhook serialization, derived from proceeding→case like `case_name`). When there's no linked proceeding/case it renders **"unlinked"** inline — so the separate **Link** column is removed.
- **Removed the Status column** (`processing_status`).
- **Removed the Received column** (`created_at`).
- **Docket description** truncated to **20 chars** (full text in the hover tooltip).
- Default sort is now **date filed** (was received, which no longer has a column).
- Removed the now-unused Link/Status faceted filters from the toolbar.

## Verified
- Frontend type-checks; backend imports clean.
- `/api/v1/webhooks` returns the new `case_short_name` field (null → renders "unlinked").