### PR TITLE
feat(events): optional event date+time with a unified picker everywhere

### DIFF
--- a/db/events.py
+++ b/db/events.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import joinedload
 
 from .session import SessionLocal
 from .connection import _NOT_PROVIDED
-from .validation import validate_date_format, validate_time_format
+from .validation import validate_date_format, validate_time_format, ValidationError
 from .feature_gates import (
     FEATURE_EVENTS, FEATURE_TASKS, feature_enabled_filter,
     require_feature_for_case, is_feature_enabled,
@@ -236,8 +236,11 @@ def update_event_full(event_id: int, date: str = _NOT_PROVIDED, description: str
         require_feature_for_case(session, event.case_id, FEATURE_EVENTS)
 
         if date is not _NOT_PROVIDED:
-            if date is not None:
-                validate_date_format(date, "date")
+            # date is NOT NULL in the DB — reject an explicit null instead of
+            # letting it hit the DB as an IntegrityError (500).
+            if date is None:
+                raise ValidationError("date is required and cannot be cleared.")
+            validate_date_format(date, "date")
             event.date = date
 
         if time is not _NOT_PROVIDED:

--- a/db/validation.py
+++ b/db/validation.py
@@ -119,11 +119,17 @@ def validate_date_format(date_str: str, field_name: str = "date") -> str:
 
 
 def validate_time_format(time_str: str, field_name: str = "time") -> str:
-    """Validate time string is in HH:MM format."""
+    """Validate time string is in HH:MM format with in-range values."""
     if time_str is None:
         return None
-    if not re.match(r'^\d{2}:\d{2}$', time_str):
+    m = re.match(r'^(\d{2}):(\d{2})$', time_str)
+    if not m:
         raise ValidationError(f"Invalid {field_name} format '{time_str}'. Must be HH:MM.")
+    hours, minutes = int(m.group(1)), int(m.group(2))
+    if hours > 23 or minutes > 59:
+        raise ValidationError(
+            f"Invalid {field_name} '{time_str}'. Hours must be 00-23 and minutes 00-59."
+        )
     return time_str
 
 

--- a/frontend/src/components/common/quick-create-dialog.tsx
+++ b/frontend/src/components/common/quick-create-dialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
-import { Input } from "@/components/ui/input"
+import { DatePicker } from "@/components/ui/date-picker"
 import { getStaff, type StaffMember } from "@/services/staff"
 import {
   quickCreate,
@@ -186,23 +186,14 @@ export function QuickCreateDialog({
                 When is <span className="font-medium">{draft.description}</span>?
               </p>
               <div className="flex items-end gap-2">
-                <div className="flex flex-col gap-1">
-                  <label className="text-muted-foreground text-[11px]">Date</label>
-                  <Input
-                    type="date"
-                    value={dateInput}
-                    onChange={(e) => setDateInput(e.target.value)}
-                    className="text-sm"
-                    autoFocus
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-muted-foreground text-[11px]">Time (optional)</label>
-                  <Input
-                    type="time"
-                    value={timeInput}
-                    onChange={(e) => setTimeInput(e.target.value)}
-                    className="text-sm"
+                <div className="flex flex-col gap-1 flex-1">
+                  <label className="text-muted-foreground text-[11px]">Date &amp; Time</label>
+                  <DatePicker
+                    value={dateInput || null}
+                    onChange={(d) => setDateInput(d ?? "")}
+                    withTime
+                    time={timeInput || null}
+                    onTimeChange={(t) => setTimeInput(t ?? "")}
                   />
                 </div>
                 <Button size="sm" onClick={submitDate} disabled={!dateInput || mutation.isPending}>

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -7,6 +7,7 @@ import { Calendar03Icon, Cancel01Icon } from "@hugeicons/core-free-icons"
 import { cn } from "@/lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
+import { Label } from "@/components/ui/label"
 
 interface DatePickerProps {
   value: string | null
@@ -17,6 +18,16 @@ interface DatePickerProps {
   variant?: "default" | "inline"
   /** Custom formatter for the trigger display text */
   formatValue?: (iso: string) => string
+  /**
+   * Enable optional time selection. When on, natural-language input keeps any
+   * explicit time ("friday at 3pm" fills both), the popover shows a time field,
+   * and the trigger appends the time. Requires `time` / `onTimeChange`.
+   */
+  withTime?: boolean
+  /** Committed time as "HH:MM" (24h). Only used when `withTime`. */
+  time?: string | null
+  /** Called with "HH:MM" (24h) or null. Only used when `withTime`. */
+  onTimeChange?: (time: string | null) => void
 }
 
 function toLocalDate(iso: string): Date {
@@ -31,6 +42,36 @@ function toISODate(date: Date): string {
   return `${y}-${m}-${d}`
 }
 
+function toTimeString(date: Date): string {
+  const h = String(date.getHours()).padStart(2, "0")
+  const m = String(date.getMinutes()).padStart(2, "0")
+  return `${h}:${m}`
+}
+
+/** "HH:MM" (24h) → "3:00 PM" for display. */
+function formatTimeDisplay(hhmm: string): string {
+  const [h, m] = hhmm.split(":").map(Number)
+  return format(new Date(2000, 0, 1, h, m), "h:mm a")
+}
+
+const WEEKDAYS = [
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+]
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+interface ParsedResult {
+  date: Date
+  /** Whether the natural-language text specified an explicit time. */
+  hasTime: boolean
+}
+
 function DatePicker({
   value,
   onChange,
@@ -38,13 +79,27 @@ function DatePicker({
   className,
   variant = "default",
   formatValue,
+  withTime = false,
+  time = null,
+  onTimeChange,
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false)
   const [inputValue, setInputValue] = React.useState("")
-  const [parsedPreview, setParsedPreview] = React.useState<Date | null>(null)
+  const [parsedPreview, setParsedPreview] = React.useState<ParsedResult | null>(null)
   const [displayMonth, setDisplayMonth] = React.useState<Date | undefined>(undefined)
+  // Local draft for the native time input. A partially-typed time reports value
+  // "" via onChange; propagating that upward would clear a saved time (and, in
+  // the edit dialog, fire an immediate PUT that wipes it). We mirror the raw
+  // input here so typing stays smooth, but only commit complete values upward.
+  const [timeDraft, setTimeDraft] = React.useState<string>(time ?? "")
   const inputRef = React.useRef<HTMLInputElement>(null)
   const valueBeforeOpen = React.useRef<string | null>(null)
+
+  // Keep the draft in sync with the committed time (external edits, reopen,
+  // NL parse filling a time). Only runs when the committed value actually moves.
+  React.useEffect(() => {
+    setTimeDraft(time ?? "")
+  }, [time])
 
   const selectedDate = value ? toLocalDate(value) : undefined
 
@@ -61,14 +116,30 @@ function DatePicker({
     }
   }, [open, value])
 
-  function parseInput(text: string): Date | null {
+  function parseInput(text: string): ParsedResult | null {
     if (!text.trim()) return null
-    const results = chrono.parse(text, new Date(), { forwardDate: true })
-    if (results.length > 0) {
-      const d = results[0].start.date()
-      return isValid(d) ? d : null
+    const now = new Date()
+    const results = chrono.parse(text, now, { forwardDate: true })
+    if (results.length === 0) return null
+    const start = results[0].start
+    const d = start.date()
+    if (!isValid(d)) return null
+    const hasTime = start.isCertain("hour")
+
+    // Law-firm bias: a bare hour with no am/pm ("at 5") almost always means PM.
+    // chrono defaults such hours to AM, so bump early-hour uncertain times to PM.
+    if (hasTime && !start.isCertain("meridiem")) {
+      const h = d.getHours()
+      if (h >= 1 && h <= 6) d.setHours(h + 12)
     }
-    return null
+
+    // A weekday name typed on that same weekday ("friday" on a Friday) should
+    // mean next week, not today. forwardDate keeps it on today; push it out.
+    const matched = results[0].text.toLowerCase()
+    const namesToday = WEEKDAYS.some((w) => matched.includes(w))
+    if (namesToday && isSameDay(d, now)) d.setDate(d.getDate() + 7)
+
+    return { date: d, hasTime }
   }
 
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -77,8 +148,13 @@ function DatePicker({
     setParsedPreview(parseInput(text))
   }
 
-  function commit(date: Date | null) {
-    onChange(date ? toISODate(date) : null)
+  function commit(parsed: ParsedResult | null) {
+    onChange(parsed ? toISODate(parsed.date) : null)
+    // Only override the time when the user actually typed one; a bare date
+    // ("next friday") leaves any existing time untouched.
+    if (withTime && parsed?.hasTime && onTimeChange) {
+      onTimeChange(toTimeString(parsed.date))
+    }
     setOpen(false)
   }
 
@@ -103,12 +179,12 @@ function DatePicker({
 
   function handleCalendarSelect(date: Date | undefined) {
     if (date) {
-      commit(date)
+      commit({ date, hasTime: false })
     }
   }
 
   // The date to highlight on the calendar: parsed preview takes priority, then committed value
-  const calendarHighlight = parsedPreview ?? selectedDate
+  const calendarHighlight = parsedPreview?.date ?? selectedDate
 
   // Sync displayed month to the highlighted date when it changes (new selection, parsed preview),
   // but allow the user to navigate freely via the calendar arrows.
@@ -119,6 +195,9 @@ function DatePicker({
   const displayText = value
     ? (formatValue ? formatValue(value) : format(toLocalDate(value), "MMM d, yyyy"))
     : placeholder
+  // Show the time even when no date is set yet, so a pending time isn't hidden
+  // (it would otherwise silently attach to whatever date is picked next).
+  const timeSuffix = withTime && time ? ` · ${formatTimeDisplay(time)}` : ""
 
   const isInline = variant === "inline"
 
@@ -141,6 +220,7 @@ function DatePicker({
           />
           <span className={cn(!isInline && "truncate")}>
             {displayText}
+            {timeSuffix && <span className="text-muted-foreground">{timeSuffix}</span>}
           </span>
         </button>
       </PopoverTrigger>
@@ -190,7 +270,9 @@ function DatePicker({
                 <span className="text-muted-foreground">
                   {"→ "}
                   <span className="text-foreground font-medium">
-                    {format(parsedPreview, "EEE, MMM d, yyyy")}
+                    {format(parsedPreview.date, "EEE, MMM d, yyyy")}
+                    {withTime && parsedPreview.hasTime &&
+                      ` at ${format(parsedPreview.date, "h:mm a")}`}
                   </span>
                 </span>
               ) : (
@@ -201,6 +283,37 @@ function DatePicker({
             </div>
           )}
         </div>
+
+        {/* Time field */}
+        {withTime && (
+          <div className="flex items-center gap-2 px-2.5 pt-2.5">
+            <Label className="text-xs text-muted-foreground shrink-0">Time</Label>
+            <input
+              type="time"
+              value={timeDraft}
+              onChange={(e) => {
+                const v = e.target.value
+                setTimeDraft(v)
+                // Commit only complete values; an incomplete/empty input must
+                // not clear the saved time (use the ✕ button to clear).
+                if (v) onTimeChange?.(v)
+              }}
+              className="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 h-8 rounded-none border bg-transparent px-2 py-1 text-xs transition-colors focus-visible:ring-1 md:text-xs flex-1 min-w-0 outline-none"
+            />
+            {timeDraft && (
+              <button
+                type="button"
+                onClick={() => {
+                  setTimeDraft("")
+                  onTimeChange?.(null)
+                }}
+                className="text-muted-foreground hover:text-foreground shrink-0"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3.5" />
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Calendar */}
         <Calendar

--- a/frontend/src/pages/cases/components/add-event-dialog.tsx
+++ b/frontend/src/pages/cases/components/add-event-dialog.tsx
@@ -76,22 +76,15 @@ export function AddEventDialog({
             />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">Date</Label>
-              <DatePicker
-                value={date || null}
-                onChange={(d) => setDate(d ?? "")}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">Time</Label>
-              <Input
-                type="time"
-                value={time}
-                onChange={(e) => setTime(e.target.value)}
-              />
-            </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs">Date &amp; Time</Label>
+            <DatePicker
+              value={date || null}
+              onChange={(d) => setDate(d ?? "")}
+              withTime
+              time={time || null}
+              onTimeChange={(t) => setTime(t ?? "")}
+            />
           </div>
 
           <div className="space-y-1.5">

--- a/frontend/src/pages/events/components/event-detail-dialog.tsx
+++ b/frontend/src/pages/events/components/event-detail-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/services/events"
 import { getStaff } from "@/services/staff"
 import { InlineEditField } from "@/components/common/inline-edit-field"
+import { DatePicker } from "@/components/ui/date-picker"
 import { DetailDialogActions } from "@/components/common/detail-dialog-actions"
 import { EventTasksSection } from "@/pages/events/components/event-tasks-section"
 import { getBadgeStyle, getAvatarStyleById } from "@/lib/badge-colors"
@@ -153,31 +154,24 @@ export function EventDetailDialog({
         </DialogHeader>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {/* Date */}
-          <div className="flex flex-col gap-1">
+          {/* Date & Time */}
+          <div className="flex flex-col gap-1 col-span-2">
             <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Date
+              Date &amp; Time
             </span>
-            <InlineEditField
+            <DatePicker
               value={detail?.date ?? event.date}
-              onSave={(v) => mutation.mutate({ field: "date", value: v })}
-              type="date"
-              className="h-7 text-xs"
-            />
-          </div>
-
-          {/* Time */}
-          <div className="flex flex-col gap-1">
-            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Time
-            </span>
-            <InlineEditField
-              value={detail?.time ?? event.time ?? ""}
-              onSave={(v) =>
-                mutation.mutate({ field: "time", value: v || null })
-              }
-              placeholder="No time"
-              className="h-7 text-xs"
+              onChange={(d) => {
+                // Events require a date — ignore a cleared value.
+                if (d) mutation.mutate({ field: "date", value: d })
+              }}
+              withTime
+              // Once detail is loaded, trust its time even when null (a cleared
+              // time must not fall back to the stale event.time list prop).
+              time={detail ? detail.time ?? null : event.time ?? null}
+              onTimeChange={(t) => mutation.mutate({ field: "time", value: t })}
+              variant="inline"
+              className="text-xs"
             />
           </div>
 

--- a/frontend/src/pages/events/components/event-list-item.tsx
+++ b/frontend/src/pages/events/components/event-list-item.tsx
@@ -243,10 +243,10 @@ export function EventListItem({
           {event.description}
         </p>
 
-        {/* Metadata row */}
-        <div className="flex items-center gap-2.5 mt-0.5">
+        {/* Metadata row — chips wrap on mobile, stay single-line at sm+ (desktop unchanged) */}
+        <div className="flex flex-wrap sm:flex-nowrap items-center gap-x-2.5 gap-y-1 mt-0.5">
           {/* Date & time — interactive (same picker everywhere) */}
-          <div onClick={(e) => e.stopPropagation()}>
+          <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
             <DatePicker
               value={event.date}
               onChange={(date) => onUpdateEvent(event.id, "date", date)}
@@ -256,6 +256,7 @@ export function EventListItem({
               withTime
               time={event.time ?? null}
               onTimeChange={(t) => onUpdateEvent(event.id, "time", t)}
+              className="whitespace-nowrap"
             />
           </div>
 

--- a/frontend/src/pages/events/components/event-list-item.tsx
+++ b/frontend/src/pages/events/components/event-list-item.tsx
@@ -44,14 +44,6 @@ function formatDate(dateStr: string): string {
   return `${base} (${dow})`
 }
 
-function formatTime(timeStr: string | null): string | null {
-  if (!timeStr) return null
-  const [h, m] = timeStr.split(":").map(Number)
-  const d = new Date()
-  d.setHours(h, m)
-  return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
-}
-
 function StaffRow({
   staffId,
   initials,
@@ -253,7 +245,7 @@ export function EventListItem({
 
         {/* Metadata row */}
         <div className="flex items-center gap-2.5 mt-0.5">
-          {/* Date — interactive */}
+          {/* Date & time — interactive (same picker everywhere) */}
           <div onClick={(e) => e.stopPropagation()}>
             <DatePicker
               value={event.date}
@@ -261,15 +253,11 @@ export function EventListItem({
               variant="inline"
               placeholder="Set date"
               formatValue={formatDate}
+              withTime
+              time={event.time ?? null}
+              onTimeChange={(t) => onUpdateEvent(event.id, "time", t)}
             />
           </div>
-
-          {/* Time */}
-          {event.time && (
-            <span className="text-xs text-muted-foreground">
-              {formatTime(event.time)}
-            </span>
-          )}
 
           {/* Location */}
           {event.location && (

--- a/routes/events.py
+++ b/routes/events.py
@@ -174,7 +174,10 @@ def register_event_routes(mcp):
             data = UpdateEventInput(**(await request.json()))
         except ValidationError as e:
             return pydantic_error(e)
-        updates = data.model_dump(exclude_none=True)
+        # exclude_unset (not exclude_none): keep explicit nulls the client sent so
+        # nullable fields like `time`/`location` can be cleared. update_event_full
+        # uses a _NOT_PROVIDED sentinel to distinguish "omitted" from "set to null".
+        updates = data.model_dump(exclude_unset=True)
         try:
             result = await asyncio.to_thread(db.update_event_full, event_id, **updates)
         except db.FeatureDisabled as e:


### PR DESCRIPTION
## Summary

Adds an optional **time** to calendar events, edited through a single unified **Date & Time** picker used consistently everywhere an event's date/time appears — create dialogs, the event detail dialog, and the event rows on both the case-detail Events card and the `/your-events` calendar page.

## What's included (3 commits)

1. **`feat(events): optional event time via unified date+time picker`**
   - Merged Date & Time picker (`DatePicker` `withTime`) across add-event, event-detail, and quick-create surfaces.
   - Backend: `exclude_unset` on update so nullable fields (`time`/`location`) can be explicitly cleared.
   - QA-hardening fixes:
     - Guard the native time input so a partial/empty value never propagates (previously fired an immediate `PUT time:null` in the edit dialog and wiped the saved time; digits were also swallowed). Local draft keeps typing smooth.
     - `validate_time_format` range-checks `HH:MM` (00–23 / 00–59) → `99:99` returns **422** instead of a 500 DatetimeFieldOverflow.
     - `update_event_full` rejects an explicit `date:null` with **422** instead of a 500 NOT NULL IntegrityError.
     - NL parsing: bare early hours (`at 5`) default to PM; a weekday typed on that same weekday resolves to next week, not today.
     - Surface a pending time in the trigger even before a date is picked.

2. **`feat(events): make event row time editable via the same date+time picker`**
   - The event-list rows (shared by the case-detail Events card and `/your-events`) had an inline date picker but a **read-only** time span. Wired `withTime`/`time`/`onTimeChange` into that same picker so clicking any event's date/time opens the identical editor; removed the dead span/helper.

3. **`fix(events): wrap event-row metadata on mobile so date+time stays readable`**
   - The metadata flex row squeezed the (now longer) date+time chip on phones, wrapping its text into a 3–4 line stack. Chips now wrap below `sm` (`flex-wrap`) while keeping the single-line layout at `sm+` (`sm:flex-nowrap`) so **desktop is unchanged**; the date+time chip is pinned to one line.

## Testing

- **Backend API:** 21/21 automated checks (date-null → 422, time out-of-range → 422, valid boundaries persist, explicit-null clears, create-path validation).
- **NL parse logic:** 16/16 against the real chrono-node (PM defaulting, weekday next-week, regressions).
- **Browser E2E (Playwright):** verified the data-loss fix (empty field → zero writes, time preserved; complete typing commits with no swallowed digits; ✕ clears), pending-time trigger, live NL previews, inline row time-edit commit, and mobile/desktop layout on both surfaces.

## Notes

- Intentionally left unchanged: Trial Calendar events (date **ranges**, no time-of-day by design) and the read-only pinned past-events row (clicking it opens the detail dialog, which already has the full picker).